### PR TITLE
moduleapi: preserve RedisModule_OnLoad export compatibility

### DIFF
--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -336,7 +336,14 @@
 #define RedisModuleCommandHistoryEntry ValkeyModuleCommandHistoryEntry
 
 /* RedisModule APIs */
-#define RedisModule_OnLoad ValkeyModule_OnLoad
+/*
+ * Keep RedisModule_OnLoad unmapped.
+ *
+ * Renaming this entry-point via macro substitution can break modules that use
+ * a linker version script to export RedisModule_OnLoad explicitly.
+ * valkey-server already supports loading both ValkeyModule_OnLoad and
+ * RedisModule_OnLoad symbols.
+ */
 #define RedisModule_Init ValkeyModule_Init
 #define RedisModule_Assert ValkeyModule_Assert
 #define RedisModule_Alloc ValkeyModule_Alloc


### PR DESCRIPTION
### Motivation
- Fix module loading failure (#547) where modules using a GNU ld `version.script` that explicitly export `RedisModule_OnLoad` failed to load because the header remapped that symbol to `ValkeyModule_OnLoad`.

### Description
- Remove the `#define RedisModule_OnLoad ValkeyModule_OnLoad` macro from `src/redismodule.h` and add a comment explaining why the `RedisModule_OnLoad` entry-point must remain unmapped, while keeping server compatibility since `valkey-server` probes both `ValkeyModule_OnLoad` and `RedisModule_OnLoad`.

### Testing
- Ran a full build with `make -j4`, compiled a minimal module that exports `RedisModule_OnLoad` via `-Wl,--version-script=...`, started `src/valkey-server` and confirmed the server log shows `Module 'hello' loaded`, so the build and validation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba00e973d8832190c94cf531ecf177)