### PR TITLE
Stop remapping `RedisModule_OnLoad`; add test module that exports it via version script

### DIFF
--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -336,7 +336,14 @@
 #define RedisModuleCommandHistoryEntry ValkeyModuleCommandHistoryEntry
 
 /* RedisModule APIs */
-#define RedisModule_OnLoad ValkeyModule_OnLoad
+/*
+ * Keep RedisModule_OnLoad unmapped.
+ *
+ * Renaming this entry-point via macro substitution can break modules that use
+ * a linker version script to export RedisModule_OnLoad explicitly.
+ * valkey-server already supports loading both ValkeyModule_OnLoad and
+ * RedisModule_OnLoad symbols.
+ */
 #define RedisModule_Init ValkeyModule_Init
 #define RedisModule_Assert ValkeyModule_Assert
 #define RedisModule_Alloc ValkeyModule_Alloc

--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -68,6 +68,7 @@ TEST_MODULES = \
     rdbloadsave.so \
     crash.so \
     cluster.so \
+    hellovalkey.so \
     helloscripting.so \
     unsupported_features.so
 
@@ -83,6 +84,13 @@ all: $(TEST_MODULES)
 
 %.so: %.xo
 	$(LD) -o $@ $^ $(SHOBJ_LDFLAGS) $(LDFLAGS) $(LIBS)
+
+hellovalkey.so: hellovalkey.xo hellovalkey.version
+ifeq ($(uname_S),Linux)
+	$(LD) -o $@ hellovalkey.xo $(SHOBJ_LDFLAGS) $(LDFLAGS) $(LIBS) -Wl,--version-script=hellovalkey.version
+else
+	$(LD) -o $@ hellovalkey.xo $(SHOBJ_LDFLAGS) $(LDFLAGS) $(LIBS)
+endif
 
 .PHONY: clean
 

--- a/tests/modules/hellovalkey.c
+++ b/tests/modules/hellovalkey.c
@@ -1,0 +1,11 @@
+#include "redismodule.h"
+
+int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+
+    if (RedisModule_Init(ctx, "hello", 1, REDISMODULE_APIVER_1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    return REDISMODULE_OK;
+}

--- a/tests/modules/hellovalkey.version
+++ b/tests/modules/hellovalkey.version
@@ -1,0 +1,4 @@
+module {
+global: RedisModule_OnLoad;
+local: *;
+};

--- a/tests/unit/moduleapi/redismodule_onload.tcl
+++ b/tests/unit/moduleapi/redismodule_onload.tcl
@@ -1,0 +1,14 @@
+set testmodule [file normalize tests/modules/hellovalkey.so]
+
+start_server {tags {"modules external:skip"}} {
+    test {module with RedisModule_OnLoad symbol exported via version script can be loaded} {
+        if {$::tcl_platform(os) eq "Linux"} {
+            set nm_out [exec nm -D $testmodule]
+            assert_match {*RedisModule_OnLoad*} $nm_out
+        }
+
+        assert_equal {OK} [r module load $testmodule]
+        verify_log_message 0 "*Legacy Redis Module*hellovalkey.so found*" 0
+        assert_equal {OK} [r module unload hello]
+    }
+}


### PR DESCRIPTION
### Motivation
- Avoid renaming the `RedisModule_OnLoad` entry-point via macro substitution because it can break modules that use a linker version script to export `RedisModule_OnLoad` explicitly.
- Ensure `valkey-server` continues to load modules that export the original `RedisModule_OnLoad` symbol.

### Description
- Stop mapping `RedisModule_OnLoad` to `ValkeyModule_OnLoad` in `src/redismodule.h` and add a comment explaining why the symbol must be left unmapped.
- Add a minimal test module `tests/modules/hellovalkey.c` that defines `RedisModule_OnLoad` and a version script `hellovalkey.version` that exports `RedisModule_OnLoad`.
- Update `tests/modules/Makefile` to build `hellovalkey.so` using the version script on Linux and include it in the test modules list.
- Add a unit test `tests/unit/moduleapi/redismodule_onload.tcl` that verifies the `RedisModule_OnLoad` symbol is exported (`nm -D` on Linux) and that the module can be loaded and unloaded by the server.

### Testing
- Built the test modules including `hellovalkey.so` (Linux path using the version script) and the build succeeded.
- Ran the new unit test `tests/unit/moduleapi/redismodule_onload.tcl` which checks the exported symbol and performs `MODULE LOAD` / `MODULE UNLOAD`, and the test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba00e973d8832190c94cf531ecf177)