### PR TITLE
Harden RESTORE count validation

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -2203,7 +2203,8 @@ int rewriteStreamObject(rio *r, robj *key, robj *o) {
 
     if (s->length) {
         /* Reconstruct the stream data using XADD commands. */
-        while (streamIteratorGetID(&si, &id, &numfields)) {
+        streamIteratorResult result;
+        while ((result = streamIteratorGetID(&si, &id, &numfields)) == STREAM_ITERATOR_FOUND) {
             /* Emit a two elements array for each item. The first is
              * the ID, the second is an array of field-value pairs. */
 
@@ -2223,6 +2224,10 @@ int rewriteStreamObject(rio *r, robj *key, robj *o) {
                     return 0;
                 }
             }
+        }
+        if (result == STREAM_ITERATOR_CORRUPT) {
+            streamIteratorStop(&si);
+            return 0;
         }
     } else {
         /* Use the XADD MAXLEN 0 trick to generate an empty stream if

--- a/src/debug.c
+++ b/src/debug.c
@@ -253,8 +253,9 @@ void xorObjectDigest(serverDb *db, robj *keyobj, unsigned char *digest, robj *o)
         streamIteratorStart(&si, objectGetVal(o), NULL, NULL, 0);
         streamID id;
         int64_t numfields;
+        streamIteratorResult result;
 
-        while (streamIteratorGetID(&si, &id, &numfields)) {
+        while ((result = streamIteratorGetID(&si, &id, &numfields)) == STREAM_ITERATOR_FOUND) {
             sds itemid = sdscatfmt(sdsempty(), "%U.%U", id.ms, id.seq);
             mixDigest(digest, itemid, sdslen(itemid));
             sdsfree(itemid);
@@ -268,6 +269,7 @@ void xorObjectDigest(serverDb *db, robj *keyobj, unsigned char *digest, robj *o)
             }
         }
         streamIteratorStop(&si);
+        if (result == STREAM_ITERATOR_CORRUPT) serverPanic("Stream listpack corruption detected");
     } else if (objectGetType(o) == OBJ_MODULE) {
         ValkeyModuleDigest md = {{0}, {0}, keyobj, db->id};
         moduleValue *mv = objectGetVal(o);

--- a/src/listpack.c
+++ b/src/listpack.c
@@ -1240,7 +1240,9 @@ int lpValidateNext(unsigned char *lp, unsigned char **pp, size_t lpbytes) {
 }
 
 /* Validate the integrity of the data structure.
- * Validates the header and scans all entries one by one. */
+ * Header sanity checks reject an impossible cached element count before the
+ * complete entry-by-entry scan. The optional callback can apply additional
+ * encoding-specific checks. Returns 1 when valid and 0 otherwise. */
 int lpValidateIntegrity(unsigned char *lp, size_t size, listpackValidateEntryCB entry_cb, void *cb_userdata) {
     /* Check that we can actually read the header. (and EOF) */
     if (size < LP_HDR_SIZE + 1) return 0;
@@ -1252,9 +1254,12 @@ int lpValidateIntegrity(unsigned char *lp, size_t size, listpackValidateEntryCB 
     /* The last byte must be the terminator. */
     if (lp[size - 1] != LP_EOF) return 0;
 
+    /* Every entry needs at least one encoding byte and one backlen byte. */
+    uint32_t numele = lpGetNumElements(lp);
+    if (numele != LP_HDR_NUMELE_UNKNOWN && numele > (size - LP_HDR_SIZE - 1) / 2) return 0;
+
     /* Validate the individual entries. */
     uint32_t count = 0;
-    uint32_t numele = lpGetNumElements(lp);
     unsigned char *p = lp + LP_HDR_SIZE;
     while (p && p[0] != LP_EOF) {
         unsigned char *prev = p;
@@ -1314,33 +1319,49 @@ static inline void lpSaveValue(unsigned char *val, unsigned int len, int64_t lva
 /* Randomly select a pair of key and value.
  * total_count is a pre-computed length/2 of the listpack (to avoid calls to lpLength)
  * 'key' and 'val' are used to store the result key value pair.
- * 'val' can be NULL if the value is not needed. */
-void lpRandomPair(unsigned char *lp, unsigned long total_count, listpackEntry *key, listpackEntry *val) {
+ * 'val' can be NULL if the value is not needed.
+ * Returns 1 after storing a complete pair and 0 if selection cannot complete.
+ * The output entries are cleared before selection. */
+int lpRandomPair(unsigned char *lp, unsigned long total_count, listpackEntry *key, listpackEntry *val) {
     unsigned char *p;
 
-    /* Avoid div by zero on corrupt listpack */
-    assert(total_count);
+    memset(key, 0, sizeof(*key));
+    if (val) memset(val, 0, sizeof(*val));
+
+    /* Avoid div by zero and out-of-range seeks on corrupt listpacks. */
+    if (total_count == 0) return 0;
 
     /* Generate even numbers, because listpack saved K-V pair */
     int r = (rand() % total_count) * 2;
-    assert((p = lpSeek(lp, r)));
+    if ((p = lpSeek(lp, r)) == NULL) return 0;
     key->sval = lpGetValue(p, &(key->slen), &(key->lval));
 
-    if (!val) return;
-    assert((p = lpNext(lp, p)));
+    /* A pair is complete only when the selected key is followed by a value.
+     * Check this even when the caller does not want the value, so a dangling
+     * trailing key in a corrupt listpack is never reported as a pair. */
+    if ((p = lpNext(lp, p)) == NULL) return 0;
+    if (!val) return 1;
     val->sval = lpGetValue(p, &(val->slen), &(val->lval));
+    return 1;
 }
 
 /* Randomly select 'count' entries and store them in the 'entries' array, which
  * needs to have space for 'count' listpackEntry structs. The order is random
- * and duplicates are possible. */
-void lpRandomEntries(unsigned char *lp, unsigned int count, listpackEntry *entries) {
+ * and duplicates are possible. Returns 'count' on success and 0 if selection
+ * cannot complete. The output array is cleared before selection. */
+unsigned int lpRandomEntries(unsigned char *lp, unsigned int count, listpackEntry *entries) {
+    if (count == 0) return 0;
+    memset(entries, 0, count * sizeof(*entries));
+
     struct pick {
         unsigned int index;
         unsigned int order;
     } *picks = lp_malloc(count * sizeof(struct pick));
     unsigned int total_size = lpLength(lp);
-    assert(total_size);
+    if (total_size == 0) {
+        lp_free(picks);
+        return 0;
+    }
     for (unsigned int i = 0; i < count; i++) {
         picks[i].index = rand() % total_size;
         picks[i].order = i;
@@ -1355,9 +1376,13 @@ void lpRandomEntries(unsigned char *lp, unsigned int count, listpackEntry *entri
     unsigned int j = 0; /* index in listpack */
     for (unsigned int i = 0; i < count; i++) {
         /* Advance listpack pointer to until we reach 'index' listpack. */
-        while (j < picks[i].index) {
+        while (j < picks[i].index && p) {
             p = lpNext(lp, p);
             j++;
+        }
+        if (!p) {
+            lp_free(picks);
+            return 0;
         }
         int storeorder = picks[i].order;
         unsigned int len = 0;
@@ -1366,13 +1391,20 @@ void lpRandomEntries(unsigned char *lp, unsigned int count, listpackEntry *entri
         lpSaveValue(str, len, llval, &entries[storeorder]);
     }
     lp_free(picks);
+    return count;
 }
 
 /* Randomly select count of key value pairs and store into 'keys' and
  * 'vals' args. The order of the picked entries is random, and the selections
  * are non-unique (repetitions are possible).
- * The 'vals' arg can be NULL in which case we skip these. */
-void lpRandomPairs(unsigned char *lp, unsigned int count, listpackEntry *keys, listpackEntry *vals) {
+ * The 'vals' arg can be NULL in which case we skip these. Returns 'count' on
+ * success and 0 if selection cannot complete. The output arrays are cleared
+ * before selection. */
+unsigned int lpRandomPairs(unsigned char *lp, unsigned int count, listpackEntry *keys, listpackEntry *vals) {
+    if (count == 0) return 0;
+    memset(keys, 0, count * sizeof(*keys));
+    if (vals) memset(vals, 0, count * sizeof(*vals));
+
     unsigned char *p, *key, *value;
     unsigned int klen = 0, vlen = 0;
     long long klval = 0, vlval = 0;
@@ -1385,8 +1417,11 @@ void lpRandomPairs(unsigned char *lp, unsigned int count, listpackEntry *keys, l
     rand_pick *picks = lp_malloc(sizeof(rand_pick) * count);
     unsigned int total_size = lpLength(lp) / 2;
 
-    /* Avoid div by zero on corrupt listpack */
-    assert(total_size);
+    /* Avoid div by zero on corrupt listpack. */
+    if (total_size == 0) {
+        lp_free(picks);
+        return 0;
+    }
 
     /* create a pool of random indexes (some may be duplicate). */
     for (unsigned int i = 0; i < count; i++) {
@@ -1403,7 +1438,7 @@ void lpRandomPairs(unsigned char *lp, unsigned int count, listpackEntry *keys, l
     p = lpSeek(lp, lpindex);
     while (p && pickindex < count) {
         key = lpGetValue(p, &klen, &klval);
-        assert((p = lpNext(lp, p)));
+        if ((p = lpNext(lp, p)) == NULL) break;
         value = lpGetValue(p, &vlen, &vlval);
         while (pickindex < count && lpindex == picks[pickindex].index) {
             int storeorder = picks[pickindex].order;
@@ -1416,15 +1451,20 @@ void lpRandomPairs(unsigned char *lp, unsigned int count, listpackEntry *keys, l
     }
 
     lp_free(picks);
+    return pickindex == count ? count : 0;
 }
 
 /* Randomly select count of key value pairs and store into 'keys' and
  * 'vals' args. The selections are unique (no repetitions), and the order of
  * the picked entries is NOT-random.
  * The 'vals' arg can be NULL in which case we skip these.
- * The return value is the number of items picked which can be lower than the
- * requested count if the listpack doesn't hold enough pairs. */
+ * The return value is the number of complete pairs stored, which can be lower
+ * than the requested count if the listpack doesn't hold enough pairs or
+ * selection cannot complete. The output arrays are cleared before selection. */
 unsigned int lpRandomPairsUnique(unsigned char *lp, unsigned int count, listpackEntry *keys, listpackEntry *vals) {
+    memset(keys, 0, count * sizeof(*keys));
+    if (vals) memset(vals, 0, count * sizeof(*vals));
+
     unsigned char *p, *key;
     unsigned int klen = 0;
     long long klval = 0;
@@ -1435,10 +1475,10 @@ unsigned int lpRandomPairsUnique(unsigned char *lp, unsigned int count, listpack
     p = lpFirst(lp);
     unsigned int picked = 0, remaining = count;
     while (picked < count && p) {
-        assert((p = lpNextRandom(lp, p, &index, remaining, 1)));
+        if ((p = lpNextRandom(lp, p, &index, remaining, 1)) == NULL) break;
         key = lpGetValue(p, &klen, &klval);
         lpSaveValue(key, klen, klval, &keys[picked]);
-        assert((p = lpNext(lp, p)));
+        if ((p = lpNext(lp, p)) == NULL) break;
         index++;
         if (vals) {
             key = lpGetValue(p, &klen, &klval);

--- a/src/listpack.h
+++ b/src/listpack.h
@@ -89,10 +89,10 @@ int lpValidateIntegrity(unsigned char *lp, size_t size, listpackValidateEntryCB 
 unsigned char *lpValidateFirst(unsigned char *lp);
 int lpValidateNext(unsigned char *lp, unsigned char **pp, size_t lpbytes);
 unsigned int lpCompare(unsigned char *p, unsigned char *s, uint32_t slen);
-void lpRandomPair(unsigned char *lp, unsigned long total_count, listpackEntry *key, listpackEntry *val);
-void lpRandomPairs(unsigned char *lp, unsigned int count, listpackEntry *keys, listpackEntry *vals);
+int lpRandomPair(unsigned char *lp, unsigned long total_count, listpackEntry *key, listpackEntry *val);
+unsigned int lpRandomPairs(unsigned char *lp, unsigned int count, listpackEntry *keys, listpackEntry *vals);
 unsigned int lpRandomPairsUnique(unsigned char *lp, unsigned int count, listpackEntry *keys, listpackEntry *vals);
-void lpRandomEntries(unsigned char *lp, unsigned int count, listpackEntry *entries);
+unsigned int lpRandomEntries(unsigned char *lp, unsigned int count, listpackEntry *entries);
 unsigned char *
 lpNextRandom(unsigned char *lp, unsigned char *p, unsigned int *index, unsigned int remaining, int even_only);
 int lpSafeToAdd(unsigned char *lp, size_t add);

--- a/src/module.c
+++ b/src/module.c
@@ -5904,6 +5904,7 @@ int VM_StreamIteratorStop(ValkeyModuleKey *key) {
  * - ENOTSUP if the key refers to a value of a type other than stream or if the
  *   key is empty
  * - EBADF if no stream iterator is associated with the key
+ * - EIO if the stream encoding is corrupt
  * - ENOENT if there are no more entries in the range of the iterator
  *
  * In practice, if VM_StreamIteratorNextID() is called after a successful call
@@ -5927,7 +5928,8 @@ int VM_StreamIteratorNextID(ValkeyModuleKey *key, ValkeyModuleStreamID *id, long
     streamIterator *si = key->iter;
     int64_t *num_ptr = &key->u.stream.numfieldsleft;
     streamID *streamid_ptr = &key->u.stream.currentid;
-    if (streamIteratorGetID(si, streamid_ptr, num_ptr)) {
+    streamIteratorResult result = streamIteratorGetID(si, streamid_ptr, num_ptr);
+    if (result == STREAM_ITERATOR_FOUND) {
         if (id) {
             id->ms = streamid_ptr->ms;
             id->seq = streamid_ptr->seq;
@@ -5939,7 +5941,7 @@ int VM_StreamIteratorNextID(ValkeyModuleKey *key, ValkeyModuleStreamID *id, long
         key->u.stream.currentid.ms = 0; /* for VM_StreamIteratorDelete() */
         key->u.stream.currentid.seq = 0;
         key->u.stream.numfieldsleft = 0; /* for VM_StreamIteratorNextField() */
-        errno = ENOENT;
+        errno = result == STREAM_ITERATOR_CORRUPT ? EIO : ENOENT;
         return VALKEYMODULE_ERR;
     }
 }

--- a/src/stream.h
+++ b/src/stream.h
@@ -51,6 +51,12 @@ typedef struct streamIterator {
     unsigned char value_buf[LP_INTBUF_SIZE];
 } streamIterator;
 
+typedef enum streamIteratorResult {
+    STREAM_ITERATOR_CORRUPT = -1,
+    STREAM_ITERATOR_EOF = 0,
+    STREAM_ITERATOR_FOUND = 1,
+} streamIteratorResult;
+
 /* Consumer group. */
 typedef struct streamCG {
     streamID last_id;       /* Last delivered (not acknowledged) ID for this
@@ -127,7 +133,7 @@ size_t streamReplyWithRange(client *c,
                             int flags,
                             streamPropInfo *spi);
 void streamIteratorStart(streamIterator *si, stream *s, streamID *start, streamID *end, int rev);
-int streamIteratorGetID(streamIterator *si, streamID *id, int64_t *numfields);
+streamIteratorResult streamIteratorGetID(streamIterator *si, streamID *id, int64_t *numfields);
 void streamIteratorGetField(streamIterator *si,
                             unsigned char **fieldptr,
                             unsigned char **valueptr,

--- a/src/t_hash.c
+++ b/src/t_hash.c
@@ -906,7 +906,7 @@ static int hashTypeRandomElement(robj *hashobj, unsigned long hashsize, listpack
         }
         hashTypeIgnoreTTL(hashobj, false);
     } else if (hashobj->encoding == OBJ_ENCODING_LISTPACK) {
-        lpRandomPair(objectGetVal(hashobj), hashsize, field, val);
+        if (!lpRandomPair(objectGetVal(hashobj), hashsize, field, val)) rc = C_ERR;
     } else {
         serverPanic("Unknown hash encoding");
     }
@@ -2212,15 +2212,15 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
             unsigned long limit, sample_count;
 
             limit = count > HRANDFIELD_RANDOM_SAMPLE_LIMIT ? HRANDFIELD_RANDOM_SAMPLE_LIMIT : count;
-            fields = zmalloc(sizeof(listpackEntry) * limit);
-            if (withvalues) vals = zmalloc(sizeof(listpackEntry) * limit);
+            fields = zcalloc(sizeof(listpackEntry) * limit);
+            if (withvalues) vals = zcalloc(sizeof(listpackEntry) * limit);
             while (count) {
-                sample_count = count > limit ? limit : count;
-                count -= sample_count;
+                unsigned long requested = count > limit ? limit : count;
+                sample_count = lpRandomPairs(objectGetVal(hash), requested, fields, vals);
+                count -= requested;
                 reply_size += sample_count;
-                lpRandomPairs(objectGetVal(hash), sample_count, fields, vals);
                 hrandfieldReplyWithListpack(wpc, sample_count, fields, vals);
-                if (c->flag.close_asap) break;
+                if (sample_count != requested || c->flag.close_asap) break;
             }
             zfree(fields);
             zfree(vals);
@@ -2255,12 +2255,11 @@ void hrandfieldWithCountCommand(client *c, long l, int withvalues) {
      * And it is inefficient to repeatedly pick one random element from a
      * listpack in CASE 4. So we use this instead. */
     if (hash->encoding == OBJ_ENCODING_LISTPACK) {
-        reply_size = count < size ? count : size;
         listpackEntry *fields, *vals = NULL;
-        fields = zmalloc(sizeof(listpackEntry) * count);
-        if (withvalues) vals = zmalloc(sizeof(listpackEntry) * count);
-        serverAssert(lpRandomPairsUnique(objectGetVal(hash), count, fields, vals) == count);
-        hrandfieldReplyWithListpack(wpc, count, fields, vals);
+        fields = zcalloc(sizeof(listpackEntry) * count);
+        if (withvalues) vals = zcalloc(sizeof(listpackEntry) * count);
+        reply_size = lpRandomPairsUnique(objectGetVal(hash), count, fields, vals);
+        hrandfieldReplyWithListpack(wpc, reply_size, fields, vals);
         zfree(fields);
         zfree(vals);
         goto set_deferred_response;

--- a/src/t_set.c
+++ b/src/t_set.c
@@ -417,8 +417,12 @@ sds setTypeNextObject(setTypeIterator *si) {
  * string which is actually an sds string and it can be used as such.
  *
  * Note that both the str, len and llele pointers should be passed and cannot
- * be NULL. If str is set to NULL, the value is an integer stored in llele. */
+ * be NULL. If str is set to NULL, the value is an integer stored in llele.
+ * Returns C_ERR if a listpack element cannot be found. */
 int setTypeRandomElement(robj *setobj, char **str, size_t *len, int64_t *llele) {
+    *str = NULL;
+    *len = 0;
+    *llele = 0;
     if (setobj->encoding == OBJ_ENCODING_HASHTABLE) {
         void *entry = NULL;
         hashtableFairRandomEntry(objectGetVal(setobj), &entry);
@@ -430,8 +434,11 @@ int setTypeRandomElement(robj *setobj, char **str, size_t *len, int64_t *llele) 
         *str = NULL; /* Not needed. Defensive. */
     } else if (setobj->encoding == OBJ_ENCODING_LISTPACK) {
         unsigned char *lp = objectGetVal(setobj);
-        int r = rand() % lpLength(lp);
+        unsigned long total_count = lpLength(lp);
+        if (total_count == 0) return C_ERR;
+        int r = rand() % total_count;
         unsigned char *p = lpSeek(lp, r);
+        if (p == NULL) return C_ERR;
         unsigned int l;
         *str = (char *)lpGetValue(p, &l, (long long *)llele);
         *len = (size_t)l;
@@ -461,6 +468,7 @@ robj *setTypePopRandom(robj *set) {
         size_t len = 0;
         int64_t llele = 0;
         int encoding = setTypeRandomElement(set, &str, &len, &llele);
+        if (encoding == C_ERR) serverPanic("Listpack corruption detected");
         if (str)
             obj = createStringObject(str, len);
         else
@@ -899,6 +907,7 @@ void spopWithCountCommand(client *c) {
         } else {
             while (remaining--) {
                 int encoding = setTypeRandomElement(set, &str, &len, &llele);
+                if (encoding == C_ERR) serverPanic("Listpack corruption detected");
                 if (!newset) {
                     newset = str ? createSetListpackObject() : createIntsetObject();
                 }
@@ -1036,31 +1045,35 @@ void srandmemberWithCountCommand(client *c) {
      * structures. This case is the only one that also needs to return the
      * elements in random order. */
     if (!uniq || count == 1) {
-        addReplyArrayLen(c, count);
-
         if (set->encoding == OBJ_ENCODING_LISTPACK && count > 1) {
             /* Specialized case for listpack, traversing it only once. */
             unsigned long limit, sample_count;
+            unsigned long reply_count = 0;
+            void *replylen = addReplyDeferredLen(c);
             limit = count > SRANDFIELD_RANDOM_SAMPLE_LIMIT ? SRANDFIELD_RANDOM_SAMPLE_LIMIT : count;
-            listpackEntry *entries = zmalloc(limit * sizeof(listpackEntry));
+            listpackEntry *entries = zcalloc(limit * sizeof(listpackEntry));
             while (count) {
-                sample_count = count > limit ? limit : count;
-                count -= sample_count;
-                lpRandomEntries(objectGetVal(set), sample_count, entries);
+                unsigned long requested = count > limit ? limit : count;
+                sample_count = lpRandomEntries(objectGetVal(set), requested, entries);
+                count -= requested;
+                reply_count += sample_count;
                 for (unsigned long i = 0; i < sample_count; i++) {
                     if (entries[i].sval)
                         addReplyBulkCBuffer(c, entries[i].sval, entries[i].slen);
                     else
                         addReplyBulkLongLong(c, entries[i].lval);
                 }
-                if (c->flag.close_asap) break;
+                if (sample_count != requested || c->flag.close_asap) break;
             }
             zfree(entries);
+            setDeferredArrayLen(c, replylen, reply_count);
             return;
         }
 
+        addReplyArrayLen(c, count);
         while (count--) {
-            setTypeRandomElement(set, &str, &len, &llele);
+            if (setTypeRandomElement(set, &str, &len, &llele) == C_ERR)
+                serverPanic("Listpack corruption detected");
             if (str == NULL) {
                 addReplyBulkLongLong(c, llele);
             } else {
@@ -1103,9 +1116,11 @@ void srandmemberWithCountCommand(client *c) {
         unsigned char *lp = objectGetVal(set);
         unsigned char *p = lpFirst(lp);
         unsigned int i = 0;
-        addReplyArrayLen(c, count);
+        void *replylen = addReplyDeferredLen(c);
+        unsigned long reply_count = 0;
         while (count) {
             p = lpNextRandom(lp, p, &i, count--, 0);
+            if (p == NULL) break;
             unsigned int len;
             str = (char *)lpGetValue(p, &len, (long long *)&llele);
             if (str == NULL) {
@@ -1113,9 +1128,11 @@ void srandmemberWithCountCommand(client *c) {
             } else {
                 addReplyBulkCBuffer(c, str, len);
             }
+            reply_count++;
             p = lpNext(lp, p);
             i++;
         }
+        setDeferredArrayLen(c, replylen, reply_count);
         return;
     }
 
@@ -1167,7 +1184,8 @@ void srandmemberWithCountCommand(client *c) {
 
         hashtableExpand(ht, count);
         while (added < count) {
-            setTypeRandomElement(set, &str, &len, &llele);
+            if (setTypeRandomElement(set, &str, &len, &llele) == C_ERR)
+                serverPanic("Listpack corruption detected");
             if (str == NULL) {
                 sdsele = sdsfromlonglong(llele);
             } else {
@@ -1215,7 +1233,8 @@ void srandmemberCommand(client *c) {
     /* Handle variant without <count> argument. Reply with simple bulk string */
     if ((set = lookupKeyReadOrReply(c, c->argv[1], shared.null[c->resp])) == NULL || checkType(c, set, OBJ_SET)) return;
 
-    setTypeRandomElement(set, &str, &len, &llele);
+    if (setTypeRandomElement(set, &str, &len, &llele) == C_ERR)
+        serverPanic("Listpack corruption detected");
     if (str == NULL) {
         addReplyBulkLongLong(c, llele);
     } else {

--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -395,8 +395,12 @@ void streamGetEdgeID(stream *s, int first, int skip_tombstones, streamID *edge_i
     int64_t numfields;
     streamIteratorStart(&si, s, NULL, NULL, !first);
     si.skip_tombstones = skip_tombstones;
-    int found = streamIteratorGetID(&si, edge_id, &numfields);
-    if (!found) {
+    streamIteratorResult result = streamIteratorGetID(&si, edge_id, &numfields);
+    if (result == STREAM_ITERATOR_CORRUPT) {
+        streamIteratorStop(&si);
+        serverPanic("Stream listpack corruption detected");
+    }
+    if (result == STREAM_ITERATOR_EOF) {
         streamID min_id = {0, 0}, max_id = {UINT64_MAX, UINT64_MAX};
         *edge_id = first ? max_id : min_id;
     }
@@ -1034,7 +1038,7 @@ static int streamParseAddOrTrimArgsOrReply(client *c, streamAddTrimArgs *args, i
  *  streamIterator myiterator;
  *  streamIteratorStart(&myiterator,...);
  *  int64_t numfields;
- *  while(streamIteratorGetID(&myiterator,&ID,&numfields)) {
+ *  while(streamIteratorGetID(&myiterator,&ID,&numfields) == STREAM_ITERATOR_FOUND) {
  *      while(numfields--) {
  *          unsigned char *key, *value;
  *          size_t key_len, value_len;
@@ -1092,52 +1096,86 @@ void streamIteratorStart(streamIterator *si, stream *s, streamID *start, streamI
     si->skip_tombstones = 1; /* By default tombstones aren't emitted. */
 }
 
-/* Return 1 and store the current item ID at 'id' if there are still
- * elements within the iteration range, otherwise return 0 in order to
- * signal the iteration terminated. */
-int streamIteratorGetID(streamIterator *si, streamID *id, int64_t *numfields) {
+static int streamIteratorValidateEntryData(streamIterator *si, int64_t flags, int64_t numfields) {
+    if (numfields < 0 || (uint64_t)numfields > lpBytes(si->lp)) return 0;
+
+    uint64_t data_entries = (flags & STREAM_ITEM_FLAG_SAMEFIELDS) ? (uint64_t)numfields : (uint64_t)numfields * 2;
+    unsigned char *p = si->lp_ele;
+    while (data_entries--) {
+        if (!p) return 0;
+        p = lpNext(si->lp, p);
+    }
+    if (!p) return 0;
+
+    int valid_record;
+    int64_t lp_count = lpGetIntegerIfValid(p, &valid_record);
+    uint64_t expected = (flags & STREAM_ITEM_FLAG_SAMEFIELDS) ? (uint64_t)numfields + 3
+                                                              : (uint64_t)numfields * 2 + 4;
+    return valid_record && lp_count >= 0 && (uint64_t)lp_count == expected;
+}
+
+/* Return STREAM_ITERATOR_FOUND and store the current item ID at 'id' if there
+ * are still valid elements within the iteration range. Return
+ * STREAM_ITERATOR_EOF when the range is exhausted and STREAM_ITERATOR_CORRUPT
+ * when the encoded entry structure is incomplete or inconsistent. */
+streamIteratorResult streamIteratorGetID(streamIterator *si, streamID *id, int64_t *numfields) {
     while (1) { /* Will stop when element > stop_key or end of radix tree. */
         /* If the current listpack is set to NULL, this is the start of the
          * iteration or the previous listpack was completely iterated.
          * Go to the next node. */
         if (si->lp == NULL || si->lp_ele == NULL) {
             if (!si->rev && !raxNext(&si->ri))
-                return 0;
+                return STREAM_ITERATOR_EOF;
             else if (si->rev && !raxPrev(&si->ri))
-                return 0;
-            serverAssert(si->ri.key_len == sizeof(streamID));
+                return STREAM_ITERATOR_EOF;
+            if (si->ri.key_len != sizeof(streamID)) return STREAM_ITERATOR_CORRUPT;
             /* Get the primary ID. */
             streamDecodeID(si->ri.key, &si->primary_id);
             /* Get the primary fields count. */
             si->lp = si->ri.data;
-            si->lp_ele = lpFirst(si->lp);            /* Seek items count */
+            si->lp_ele = lpFirst(si->lp); /* Seek items count. */
+            if (!si->lp_ele) return STREAM_ITERATOR_CORRUPT;
             si->lp_ele = lpNext(si->lp, si->lp_ele); /* Seek deleted count. */
+            if (!si->lp_ele) return STREAM_ITERATOR_CORRUPT;
             si->lp_ele = lpNext(si->lp, si->lp_ele); /* Seek num fields. */
-            si->primary_fields_count = lpGetInteger(si->lp_ele);
+            if (!si->lp_ele) return STREAM_ITERATOR_CORRUPT;
+            int valid_record;
+            int64_t primary_fields_count = lpGetIntegerIfValid(si->lp_ele, &valid_record);
+            if (!valid_record || primary_fields_count < 0 || (uint64_t)primary_fields_count > lpBytes(si->lp))
+                return STREAM_ITERATOR_CORRUPT;
+            si->primary_fields_count = primary_fields_count;
             si->lp_ele = lpNext(si->lp, si->lp_ele); /* Seek first field. */
             si->primary_fields_start = si->lp_ele;
-            /* We are now pointing to the first field of the primary entry.
-             * We need to seek either the first or the last entry depending
-             * on the direction of the iteration. */
-            if (!si->rev) {
-                /* If we are iterating in normal order, skip the primary fields
-                 * to seek the first actual entry. */
-                for (uint64_t i = 0; i < si->primary_fields_count; i++) si->lp_ele = lpNext(si->lp, si->lp_ele);
-            } else {
+
+            /* Verify all primary fields and leave the forward cursor on the zero terminator. */
+            for (uint64_t i = 0; i < si->primary_fields_count; i++) {
+                if (!si->lp_ele) return STREAM_ITERATOR_CORRUPT;
+                si->lp_ele = lpNext(si->lp, si->lp_ele);
+            }
+            if (!si->lp_ele || lpGetIntegerIfValid(si->lp_ele, &valid_record) != 0 || !valid_record)
+                return STREAM_ITERATOR_CORRUPT;
+
+            if (si->rev) {
                 /* If we are iterating in reverse direction, just seek the
                  * last part of the last entry in the listpack (that is, the
                  * fields count). */
                 si->lp_ele = lpLast(si->lp);
+                if (!si->lp_ele) return STREAM_ITERATOR_CORRUPT;
             }
         } else if (si->rev) {
             /* If we are iterating in the reverse order, and this is not
              * the first entry emitted for this listpack, then we already
              * emitted the current entry, and have to go back to the previous
              * one. */
-            int64_t lp_count = lpGetInteger(si->lp_ele);
-            while (lp_count--) si->lp_ele = lpPrev(si->lp, si->lp_ele);
+            int valid_record;
+            int64_t lp_count = lpGetIntegerIfValid(si->lp_ele, &valid_record);
+            if (!valid_record || lp_count < 0 || (uint64_t)lp_count > lpBytes(si->lp))
+                return STREAM_ITERATOR_CORRUPT;
+            while (lp_count-- && si->lp_ele) si->lp_ele = lpPrev(si->lp, si->lp_ele);
+            if (!si->lp_ele) return STREAM_ITERATOR_CORRUPT;
             /* Seek lp-count of prev entry. */
             si->lp_ele = lpPrev(si->lp, si->lp_ele);
+            if (!si->lp_ele) return STREAM_ITERATOR_CORRUPT;
         }
 
         /* For every radix tree node, iterate the corresponding listpack,
@@ -1153,55 +1191,70 @@ int streamIteratorGetID(streamIterator *si, streamID *id, int64_t *numfields) {
                 /* If we are going backward, read the number of elements this
                  * entry is composed of, and jump backward N times to seek
                  * its start. */
-                int64_t lp_count = lpGetInteger(si->lp_ele);
+                int valid_record;
+                int64_t lp_count = lpGetIntegerIfValid(si->lp_ele, &valid_record);
+                if (!valid_record || lp_count < 0 || (uint64_t)lp_count > lpBytes(si->lp))
+                    return STREAM_ITERATOR_CORRUPT;
                 if (lp_count == 0) { /* We reached the primary entry. */
                     si->lp = NULL;
                     si->lp_ele = NULL;
                     break;
                 }
-                while (lp_count--) si->lp_ele = lpPrev(si->lp, si->lp_ele);
+                while (lp_count-- && si->lp_ele) si->lp_ele = lpPrev(si->lp, si->lp_ele);
+                if (!si->lp_ele) return STREAM_ITERATOR_CORRUPT;
             }
 
             /* Get the flags entry. */
             si->lp_flags = si->lp_ele;
-            int64_t flags = lpGetInteger(si->lp_ele);
+            int valid_record;
+            int64_t flags = lpGetIntegerIfValid(si->lp_ele, &valid_record);
+            if (!valid_record) return STREAM_ITERATOR_CORRUPT;
             si->lp_ele = lpNext(si->lp, si->lp_ele); /* Seek ID. */
+            if (!si->lp_ele) return STREAM_ITERATOR_CORRUPT;
 
             /* Get the ID: it is encoded as difference between the primary
              * ID and this entry ID. */
             *id = si->primary_id;
-            id->ms += lpGetInteger(si->lp_ele);
+            id->ms += lpGetIntegerIfValid(si->lp_ele, &valid_record);
+            if (!valid_record) return STREAM_ITERATOR_CORRUPT;
             si->lp_ele = lpNext(si->lp, si->lp_ele);
-            id->seq += lpGetInteger(si->lp_ele);
+            if (!si->lp_ele) return STREAM_ITERATOR_CORRUPT;
+            id->seq += lpGetIntegerIfValid(si->lp_ele, &valid_record);
+            if (!valid_record) return STREAM_ITERATOR_CORRUPT;
             si->lp_ele = lpNext(si->lp, si->lp_ele);
+            if (!si->lp_ele) return STREAM_ITERATOR_CORRUPT;
 
             /* The number of entries is here or not depending on the
              * flags. */
             if (flags & STREAM_ITEM_FLAG_SAMEFIELDS) {
                 *numfields = si->primary_fields_count;
             } else {
-                *numfields = lpGetInteger(si->lp_ele);
+                *numfields = lpGetIntegerIfValid(si->lp_ele, &valid_record);
+                if (!valid_record) return STREAM_ITERATOR_CORRUPT;
                 si->lp_ele = lpNext(si->lp, si->lp_ele);
+                if (!si->lp_ele) return STREAM_ITERATOR_CORRUPT;
             }
-            serverAssert(*numfields >= 0);
+            if (!streamIteratorValidateEntryData(si, flags, *numfields)) return STREAM_ITERATOR_CORRUPT;
 
             /* If current >= start, and the entry is not marked as
              * deleted or tombstones are included, emit it. */
             if (!si->rev) {
                 if (streamCompareID(id, &si->start_id) >= 0 &&
                     (!si->skip_tombstones || !(flags & STREAM_ITEM_FLAG_DELETED))) {
-                    if (streamCompareID(id, &si->end_id) > 0) return 0; /* We are already out of range. */
+                    if (streamCompareID(id, &si->end_id) > 0)
+                        return STREAM_ITERATOR_EOF; /* We are already out of range. */
                     si->entry_flags = flags;
                     if (flags & STREAM_ITEM_FLAG_SAMEFIELDS) si->primary_fields_ptr = si->primary_fields_start;
-                    return 1; /* Valid item returned. */
+                    return STREAM_ITERATOR_FOUND;
                 }
             } else {
                 if (streamCompareID(id, &si->end_id) <= 0 &&
                     (!si->skip_tombstones || !(flags & STREAM_ITEM_FLAG_DELETED))) {
-                    if (streamCompareID(id, &si->start_id) < 0) return 0; /* We are already out of range. */
+                    if (streamCompareID(id, &si->start_id) < 0)
+                        return STREAM_ITERATOR_EOF; /* We are already out of range. */
                     si->entry_flags = flags;
                     if (flags & STREAM_ITEM_FLAG_SAMEFIELDS) si->primary_fields_ptr = si->primary_fields_start;
-                    return 1; /* Valid item returned. */
+                    return STREAM_ITERATOR_FOUND;
                 }
             }
 
@@ -1218,7 +1271,8 @@ int streamIteratorGetID(streamIterator *si, streamID *id, int64_t *numfields) {
                 /* If the entry was not flagged SAMEFIELD we also read the
                  * number of fields, so go back one more. */
                 if (!(flags & STREAM_ITEM_FLAG_SAMEFIELDS)) prev_times++;
-                while (prev_times--) si->lp_ele = lpPrev(si->lp, si->lp_ele);
+                while (prev_times-- && si->lp_ele) si->lp_ele = lpPrev(si->lp, si->lp_ele);
+                if (!si->lp_ele) return STREAM_ITERATOR_CORRUPT;
             }
         }
 
@@ -1323,9 +1377,10 @@ int streamEntryExists(stream *s, streamID *id) {
     streamIteratorStart(&si, s, id, id, 0);
     streamID myid;
     int64_t numfields;
-    int found = streamIteratorGetID(&si, &myid, &numfields);
+    streamIteratorResult result = streamIteratorGetID(&si, &myid, &numfields);
     streamIteratorStop(&si);
-    if (!found) return 0;
+    if (result == STREAM_ITERATOR_CORRUPT) serverPanic("Stream listpack corruption detected");
+    if (result == STREAM_ITERATOR_EOF) return 0;
     serverAssert(streamCompareID(id, &myid) == 0);
     return 1;
 }
@@ -1338,11 +1393,13 @@ int streamDeleteItem(stream *s, streamID *id) {
     streamIteratorStart(&si, s, id, id, 0);
     streamID myid;
     int64_t numfields;
-    if (streamIteratorGetID(&si, &myid, &numfields)) {
+    streamIteratorResult result = streamIteratorGetID(&si, &myid, &numfields);
+    if (result == STREAM_ITERATOR_FOUND) {
         streamIteratorRemoveEntry(&si, &myid);
         deleted = 1;
     }
     streamIteratorStop(&si);
+    if (result == STREAM_ITERATOR_CORRUPT) serverPanic("Stream listpack corruption detected");
     return deleted;
 }
 
@@ -1351,7 +1408,9 @@ void streamLastValidID(stream *s, streamID *maxid) {
     streamIterator si;
     streamIteratorStart(&si, s, NULL, NULL, 1);
     int64_t numfields;
-    if (!streamIteratorGetID(&si, maxid, &numfields) && s->length)
+    streamIteratorResult result = streamIteratorGetID(&si, maxid, &numfields);
+    if (result == STREAM_ITERATOR_CORRUPT) serverPanic("Stream listpack corruption detected");
+    if (result == STREAM_ITERATOR_EOF && s->length)
         serverPanic("Corrupt stream, length is %llu, but no max id", (unsigned long long)s->length);
     streamIteratorStop(&si);
 }
@@ -1684,6 +1743,7 @@ size_t streamReplyWithRange(client *c,
     streamIterator si;
     int64_t numfields;
     streamID id;
+    streamIteratorResult result;
     int propagate_last_id = 0;
     int noack = flags & STREAM_RWR_NOACK;
 
@@ -1700,7 +1760,7 @@ size_t streamReplyWithRange(client *c,
 
     if (!(flags & STREAM_RWR_RAWENTRIES)) arraylen_ptr = addReplyDeferredLen(c);
     streamIteratorStart(&si, s, start, end, rev);
-    while (streamIteratorGetID(&si, &id, &numfields)) {
+    while ((result = streamIteratorGetID(&si, &id, &numfields)) == STREAM_ITERATOR_FOUND) {
         /* Update the group last_id if needed. */
         if (group && streamCompareID(&id, &group->last_id) > 0) {
             if (group->entries_read != SCG_INVALID_ENTRIES_READ &&
@@ -1790,6 +1850,15 @@ size_t streamReplyWithRange(client *c,
 
         arraylen++;
         if (count && count == arraylen) break;
+    }
+
+    if (result == STREAM_ITERATOR_CORRUPT) {
+        /* The reply length is deferred, so the entries validated so far can be
+         * returned with a correct length instead of stopping the server. The
+         * corrupt entry and everything after it in this listpack is omitted.
+         * Callers that asked for raw entries own the reply framing and detect
+         * the short count through the return value. */
+        serverLog(LL_WARNING, "Corrupt stream listpack detected, returning %llu entries", (unsigned long long)arraylen);
     }
 
     if (spi && propagate_last_id) streamPropagateGroupID(c, spi->keyname, group, spi->groupname);
@@ -3976,15 +4045,19 @@ void xinfoCommand(client *c) {
     }
 }
 
-/* Validate the integrity stream listpack entries structure. Both in term of a
- * valid listpack, but also that the structure of the entries matches a valid
- * stream. return 1 if valid 0 if not valid. */
+/* Validate both the listpack structure and the stream-specific record
+ * layout. Counts must be non-negative, fit within the remaining listpack
+ * entries, and agree with the number of records consumed. Returns 1 when
+ * valid and 0 otherwise. */
 int streamValidateListpackIntegrity(unsigned char *lp, size_t size) {
     int valid_record;
     unsigned char *p, *next;
 
     /* Validate the listpack structure (header + all entries). */
     if (!lpValidateIntegrity(lp, size, NULL, NULL)) return 0;
+
+    uint64_t lp_entries = lpLength(lp);
+    if (lp_entries < 4) return 0;
 
     next = p = lpValidateFirst(lp);
     if (!lpValidateNext(lp, &next, size)) return 0;
@@ -4004,7 +4077,7 @@ int streamValidateListpackIntegrity(unsigned char *lp, size_t size) {
 
     /* num-of-fields */
     int64_t primary_fields = lpGetIntegerIfValid(p, &valid_record);
-    if (!valid_record) return 0;
+    if (!valid_record || primary_fields < 0 || (uint64_t)primary_fields > lp_entries - 4) return 0;
     p = next;
     if (!lpValidateNext(lp, &next, size)) return 0;
 
@@ -4020,12 +4093,24 @@ int streamValidateListpackIntegrity(unsigned char *lp, size_t size) {
     p = next;
     if (!lpValidateNext(lp, &next, size)) return 0;
 
-    entry_count += deleted_count;
-    while (entry_count--) {
-        if (!p) return 0;
+    if (entry_count < 0 || deleted_count < 0 || entry_count > INT64_MAX - deleted_count) return 0;
+    int64_t total_count = entry_count + deleted_count;
+    uint64_t actual_entry_count = 0;
+    uint64_t actual_deleted_count = 0;
+
+    uint64_t consumed = (uint64_t)primary_fields + 4;
+    if ((uint64_t)total_count > (lp_entries - consumed) / 4) return 0;
+
+    while (total_count--) {
+        if (!p || lp_entries - consumed < 4) return 0;
         int64_t fields = primary_fields, extra_fields = 3;
+        consumed += 3; /* flags + two ID parts */
         int64_t flags = lpGetIntegerIfValid(p, &valid_record);
         if (!valid_record) return 0;
+        if (flags & STREAM_ITEM_FLAG_DELETED)
+            actual_deleted_count++;
+        else
+            actual_entry_count++;
         p = next;
         if (!lpValidateNext(lp, &next, size)) return 0;
 
@@ -4042,9 +4127,12 @@ int streamValidateListpackIntegrity(unsigned char *lp, size_t size) {
         if (!(flags & STREAM_ITEM_FLAG_SAMEFIELDS)) {
             /* num-of-fields */
             fields = lpGetIntegerIfValid(p, &valid_record);
-            if (!valid_record) return 0;
+            if (!valid_record || fields < 0) return 0;
             p = next;
             if (!lpValidateNext(lp, &next, size)) return 0;
+            consumed++;
+
+            if (lp_entries - consumed < 1 || (uint64_t)fields > (lp_entries - consumed - 1) / 2) return 0;
 
             /* the field names */
             for (int64_t j = 0; j < fields; j++) {
@@ -4053,7 +4141,11 @@ int streamValidateListpackIntegrity(unsigned char *lp, size_t size) {
             }
 
             extra_fields += fields + 1;
+        } else if ((uint64_t)fields > lp_entries - consumed - 1) {
+            return 0;
         }
+
+        consumed += (flags & STREAM_ITEM_FLAG_SAMEFIELDS) ? (uint64_t)fields + 1 : (uint64_t)fields * 2 + 1;
 
         /* the values */
         for (int64_t j = 0; j < fields; j++) {
@@ -4069,7 +4161,9 @@ int streamValidateListpackIntegrity(unsigned char *lp, size_t size) {
         if (!lpValidateNext(lp, &next, size)) return 0;
     }
 
-    if (next) return 0;
+    if (next || consumed != lp_entries || actual_entry_count != (uint64_t)entry_count ||
+        actual_deleted_count != (uint64_t)deleted_count)
+        return 0;
 
     return 1;
 }

--- a/src/t_zset.c
+++ b/src/t_zset.c
@@ -1773,7 +1773,7 @@ void zsetReplyFromListpackEntry(client *c, listpackEntry *e) {
  * 'key' and 'val' will be set to hold the element.
  * The memory in `key` is not to be freed or modified by the caller.
  * 'score' can be NULL in which case it's not extracted. */
-static void zsetTypeRandomElement(robj *zsetobj, unsigned long zsetsize, listpackEntry *key, double *score) {
+static int zsetTypeRandomElement(robj *zsetobj, unsigned long zsetsize, listpackEntry *key, double *score) {
     if (zsetobj->encoding == OBJ_ENCODING_SKIPLIST) {
         zset *zs = objectGetVal(zsetobj);
         void *entry;
@@ -1785,7 +1785,7 @@ static void zsetTypeRandomElement(robj *zsetobj, unsigned long zsetsize, listpac
         if (score) *score = node->score;
     } else if (zsetobj->encoding == OBJ_ENCODING_LISTPACK) {
         listpackEntry val;
-        lpRandomPair(objectGetVal(zsetobj), zsetsize, key, &val);
+        if (!lpRandomPair(objectGetVal(zsetobj), zsetsize, key, &val)) return 0;
         if (score) {
             if (val.sval) {
                 *score = zzlStrtod(val.sval, val.slen);
@@ -1796,6 +1796,7 @@ static void zsetTypeRandomElement(robj *zsetobj, unsigned long zsetsize, listpac
     } else {
         serverPanic("Unknown zset encoding");
     }
+    return 1;
 }
 
 /*-----------------------------------------------------------------------------
@@ -4182,11 +4183,11 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
      * structures. This case is the only one that also needs to return the
      * elements in random order. */
     if (!uniq || count == 1) {
-        if (withscores && c->resp == 2)
-            addReplyArrayLen(c, count * 2);
-        else
-            addReplyArrayLen(c, count);
         if (zsetobj->encoding == OBJ_ENCODING_SKIPLIST) {
+            if (withscores && c->resp == 2)
+                addReplyArrayLen(c, count * 2);
+            else
+                addReplyArrayLen(c, count);
             zset *zs = objectGetVal(zsetobj);
             while (count--) {
                 void *entry;
@@ -4201,18 +4202,22 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
         } else if (zsetobj->encoding == OBJ_ENCODING_LISTPACK) {
             listpackEntry *keys, *vals = NULL;
             unsigned long limit, sample_count;
+            unsigned long reply_size = 0;
+            void *replylen = addReplyDeferredLen(c);
             limit = count > ZRANDMEMBER_RANDOM_SAMPLE_LIMIT ? ZRANDMEMBER_RANDOM_SAMPLE_LIMIT : count;
-            keys = zmalloc(sizeof(listpackEntry) * limit);
-            if (withscores) vals = zmalloc(sizeof(listpackEntry) * limit);
+            keys = zcalloc(sizeof(listpackEntry) * limit);
+            if (withscores) vals = zcalloc(sizeof(listpackEntry) * limit);
             while (count) {
-                sample_count = count > limit ? limit : count;
-                count -= sample_count;
-                lpRandomPairs(objectGetVal(zsetobj), sample_count, keys, vals);
+                unsigned long requested = count > limit ? limit : count;
+                sample_count = lpRandomPairs(objectGetVal(zsetobj), requested, keys, vals);
+                count -= requested;
+                reply_size += sample_count;
                 zrandmemberReplyWithListpack(c, sample_count, keys, vals);
-                if (c->flag.close_asap) break;
+                if (sample_count != requested || c->flag.close_asap) break;
             }
             zfree(keys);
             zfree(vals);
+            setDeferredArrayLen(c, replylen, withscores && c->resp == 2 ? reply_size * 2 : reply_size);
         }
         return;
     }
@@ -4227,7 +4232,10 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
 
     /* Initiate reply count, RESP3 responds with nested array, RESP2 with flat one. */
     long reply_size = count < size ? count : size;
-    if (withscores && c->resp == 2)
+    void *replylen = NULL;
+    if (zsetobj->encoding == OBJ_ENCODING_LISTPACK && count < size)
+        replylen = addReplyDeferredLen(c);
+    else if (withscores && c->resp == 2)
         addReplyArrayLen(c, reply_size * 2);
     else
         addReplyArrayLen(c, reply_size);
@@ -4255,12 +4263,13 @@ void zrandmemberWithCountCommand(client *c, long l, int withscores) {
      * listpack in CASE 4. So we use this instead. */
     if (zsetobj->encoding == OBJ_ENCODING_LISTPACK) {
         listpackEntry *keys, *vals = NULL;
-        keys = zmalloc(sizeof(listpackEntry) * count);
-        if (withscores) vals = zmalloc(sizeof(listpackEntry) * count);
-        serverAssert(lpRandomPairsUnique(objectGetVal(zsetobj), count, keys, vals) == count);
-        zrandmemberReplyWithListpack(c, count, keys, vals);
+        keys = zcalloc(sizeof(listpackEntry) * count);
+        if (withscores) vals = zcalloc(sizeof(listpackEntry) * count);
+        reply_size = lpRandomPairsUnique(objectGetVal(zsetobj), count, keys, vals);
+        zrandmemberReplyWithListpack(c, reply_size, keys, vals);
         zfree(keys);
         zfree(vals);
+        setDeferredArrayLen(c, replylen, withscores && c->resp == 2 ? reply_size * 2 : reply_size);
         zuiClearIterator(&src);
         return;
     }
@@ -4377,8 +4386,10 @@ void zrandmemberCommand(client *c) {
         return;
     }
 
-    zsetTypeRandomElement(zset, zsetLength(zset), &ele, NULL);
-    zsetReplyFromListpackEntry(c, &ele);
+    if (zsetTypeRandomElement(zset, zsetLength(zset), &ele, NULL))
+        zsetReplyFromListpackEntry(c, &ele);
+    else
+        addReplyNull(c);
 }
 
 /* ZMPOP/BZMPOP

--- a/src/unit/test_listpack.cpp
+++ b/src/unit/test_listpack.cpp
@@ -1127,6 +1127,118 @@ TEST_F(ListpackBenchmark, DISABLED_listpackBenchmarkLpSeek) {
     printf("Done. usec=%lld\n", usec() - start);
 }
 
+/* The random selection helpers below are reachable with a cached element count
+ * that disagrees with the listpack contents. They must fail closed rather than
+ * assert or leave output entries uninitialized, because callers reply with
+ * whatever the output array holds. */
+class ListpackCorruptSelectionTest : public ::testing::Test {
+  protected:
+    void SetUp() override {
+        srand(0);
+    }
+};
+
+/* A caller whose cached count is zero must not divide by zero. */
+TEST_F(ListpackCorruptSelectionTest, listpackRandomPairRejectsZeroCount) {
+    listpackEntry key, val;
+    unsigned char *lp = lpNew(0);
+
+    ASSERT_EQ(lpRandomPair(lp, 0, &key, &val), 0);
+    ASSERT_TRUE(key.sval == nullptr);
+    ASSERT_EQ(key.slen, 0u);
+    ASSERT_EQ(key.lval, 0);
+    ASSERT_TRUE(val.sval == nullptr);
+    ASSERT_EQ(val.lval, 0);
+    lpFree(lp);
+}
+
+/* An odd number of elements cannot form a complete pair. The value entry must
+ * stay cleared so a caller cannot emit a fabricated value. */
+TEST_F(ListpackCorruptSelectionTest, listpackRandomPairRejectsMissingValue) {
+    listpackEntry key, val;
+    unsigned char *lp = lpNew(0);
+    lp = lpAppend(lp, (unsigned char *)("abc"), 3);
+
+    ASSERT_EQ(lpRandomPair(lp, 1, &key, &val), 0);
+    ASSERT_TRUE(val.sval == nullptr);
+    ASSERT_EQ(val.slen, 0u);
+    ASSERT_EQ(val.lval, 0);
+    lpFree(lp);
+}
+
+/* A caller that does not want the value must still not accept a dangling
+ * trailing key, because it would report a field with no value behind it. */
+TEST_F(ListpackCorruptSelectionTest, listpackRandomPairRejectsMissingValueWithoutValArg) {
+    listpackEntry key;
+    unsigned char *lp = lpNew(0);
+    lp = lpAppend(lp, (unsigned char *)("abc"), 3);
+
+    ASSERT_EQ(lpRandomPair(lp, 1, &key, nullptr), 0);
+    lpFree(lp);
+}
+
+/* A nonzero cached count over an empty listpack makes the seek fail for every
+ * index, so this exercises the failed seek without depending on the values
+ * rand() happens to produce. */
+TEST_F(ListpackCorruptSelectionTest, listpackRandomPairRejectsFailedSeek) {
+    listpackEntry key, val;
+    unsigned char *lp = lpNew(0);
+
+    ASSERT_EQ(lpRandomPair(lp, 4, &key, &val), 0);
+    ASSERT_TRUE(key.sval == nullptr);
+    ASSERT_EQ(key.slen, 0u);
+    ASSERT_EQ(key.lval, 0);
+    ASSERT_TRUE(val.sval == nullptr);
+    ASSERT_EQ(val.lval, 0);
+    lpFree(lp);
+}
+
+TEST_F(ListpackCorruptSelectionTest, listpackRandomEntriesRejectsEmptyListpack) {
+    listpackEntry entries[3];
+    unsigned char *lp = lpNew(0);
+
+    ASSERT_EQ(lpRandomEntries(lp, 3, entries), 0u);
+    for (int i = 0; i < 3; i++) {
+        ASSERT_TRUE(entries[i].sval == nullptr);
+        ASSERT_EQ(entries[i].slen, 0u);
+        ASSERT_EQ(entries[i].lval, 0);
+    }
+    lpFree(lp);
+}
+
+/* Partial pair selection is all-or-zero, and the output arrays are cleared, so
+ * a caller can never serialize uninitialized heap contents. */
+TEST_F(ListpackCorruptSelectionTest, listpackRandomPairsRejectsIncompletePair) {
+    listpackEntry keys[3], vals[3];
+    unsigned char *lp = lpNew(0);
+    lp = lpAppend(lp, (unsigned char *)("abc"), 3);
+
+    ASSERT_EQ(lpRandomPairs(lp, 3, keys, vals), 0u);
+    for (int i = 0; i < 3; i++) {
+        ASSERT_TRUE(keys[i].sval == nullptr);
+        ASSERT_EQ(keys[i].lval, 0);
+        ASSERT_TRUE(vals[i].sval == nullptr);
+        ASSERT_EQ(vals[i].lval, 0);
+    }
+    lpFree(lp);
+}
+
+/* Unique selection stops at the truncated pair and reports only the pairs it
+ * fully stored. */
+TEST_F(ListpackCorruptSelectionTest, listpackRandomPairsUniqueStopsAtTruncatedPair) {
+    listpackEntry keys[2], vals[2];
+    unsigned char *lp = lpNew(0);
+    lp = lpAppend(lp, (unsigned char *)("abc"), 3);
+    lp = lpAppend(lp, (unsigned char *)("123"), 3);
+    lp = lpAppend(lp, (unsigned char *)("def"), 3);
+
+    ASSERT_EQ(lpRandomPairsUnique(lp, 2, keys, vals), 1u);
+    ASSERT_TRUE(vals[1].sval == nullptr);
+    ASSERT_EQ(vals[1].slen, 0u);
+    ASSERT_EQ(vals[1].lval, 0);
+    lpFree(lp);
+}
+
 TEST_F(ListpackBenchmark, DISABLED_listpackBenchmarkLpValidateIntegrity) {
     /* Benchmark lpValidateIntegrity */
     unsigned long long start = usec();

--- a/src/unit/test_t_stream.cpp
+++ b/src/unit/test_t_stream.cpp
@@ -9,7 +9,90 @@
 #include <cstring>
 
 extern "C" {
+#include "listpack.h"
 #include "stream.h"
+}
+
+/* Mirrors of the record flags private to t_stream.c. */
+#define TEST_STREAM_ITEM_FLAG_DELETED (1 << 0)
+#define TEST_STREAM_ITEM_FLAG_SAMEFIELDS (1 << 1)
+
+/* Build a structurally valid stream listpack holding two same-fields records.
+ * The declared header counts and the per-record deleted flags are supplied
+ * separately so a caller can describe a header whose live/deleted split
+ * disagrees with the records that actually follow. */
+static unsigned char *buildTwoRecordStreamListpack(long long declared_live,
+                                                   long long declared_deleted,
+                                                   int first_deleted,
+                                                   int second_deleted) {
+    unsigned char *lp = lpNew(0);
+
+    /* Primary entry: count, deleted, num-master-fields, field, terminator. */
+    lp = lpAppendInteger(lp, declared_live);
+    lp = lpAppendInteger(lp, declared_deleted);
+    lp = lpAppendInteger(lp, 1);
+    lp = lpAppend(lp, (unsigned char *)"f", 1);
+    lp = lpAppendInteger(lp, 0);
+
+    /* Two records, each reusing the master field, so lp-count is 1 field
+     * plus the three fixed elements. */
+    for (int i = 0; i < 2; i++) {
+        int deleted = i == 0 ? first_deleted : second_deleted;
+        long long flags = TEST_STREAM_ITEM_FLAG_SAMEFIELDS;
+        if (deleted) flags |= TEST_STREAM_ITEM_FLAG_DELETED;
+
+        lp = lpAppendInteger(lp, flags);
+        lp = lpAppendInteger(lp, 0); /* ms diff */
+        lp = lpAppendInteger(lp, i); /* seq diff */
+        lp = lpAppend(lp, (unsigned char *)(i == 0 ? "v1" : "v2"), 2);
+        lp = lpAppendInteger(lp, 4);
+    }
+
+    return lp;
+}
+
+class StreamListpackIntegrityTest : public ::testing::Test {};
+
+/* Control: the header split matches the records, so the payload is accepted.
+ * This keeps the mismatch tests below honest by proving the hand-built
+ * fixture is otherwise structurally valid. */
+TEST_F(StreamListpackIntegrityTest, TestAcceptsMatchingLiveAndDeletedCounts) {
+    unsigned char *lp = buildTwoRecordStreamListpack(2, 0, 0, 0);
+    ASSERT_EQ(lpLength(lp), 15u);
+    ASSERT_EQ(streamValidateListpackIntegrity(lp, lpBytes(lp)), 1);
+    lpFree(lp);
+}
+
+TEST_F(StreamListpackIntegrityTest, TestAcceptsMatchingDeletedRecord) {
+    unsigned char *lp = buildTwoRecordStreamListpack(1, 1, 0, 1);
+    ASSERT_EQ(streamValidateListpackIntegrity(lp, lpBytes(lp)), 1);
+    lpFree(lp);
+}
+
+/* Both records are live, but the header claims one live and one deleted.
+ * The total still equals two, so a total-only check accepts this payload
+ * while the live count is understated. A later deletion can then decrement
+ * a zero live count and corrupt the stream. */
+TEST_F(StreamListpackIntegrityTest, TestRejectsUnderstatedLiveCount) {
+    unsigned char *lp = buildTwoRecordStreamListpack(1, 1, 0, 0);
+    ASSERT_EQ(lpLength(lp), 15u);
+    ASSERT_EQ(streamValidateListpackIntegrity(lp, lpBytes(lp)), 0);
+    lpFree(lp);
+}
+
+/* The mirrored case: one record is flagged deleted while the header claims
+ * two live records and no deleted ones. The total again matches. */
+TEST_F(StreamListpackIntegrityTest, TestRejectsOverstatedLiveCount) {
+    unsigned char *lp = buildTwoRecordStreamListpack(2, 0, 0, 1);
+    ASSERT_EQ(streamValidateListpackIntegrity(lp, lpBytes(lp)), 0);
+    lpFree(lp);
+}
+
+/* Every record is flagged deleted while the header claims both are live. */
+TEST_F(StreamListpackIntegrityTest, TestRejectsAllRecordsDeletedWithLiveHeader) {
+    unsigned char *lp = buildTwoRecordStreamListpack(2, 0, 1, 1);
+    ASSERT_EQ(streamValidateListpackIntegrity(lp, lpBytes(lp)), 0);
+    lpFree(lp);
 }
 
 class StreamIdTest : public ::testing::Test {};

--- a/src/valkey-check-rdb.c
+++ b/src/valkey-check-rdb.c
@@ -44,6 +44,7 @@
 void createSharedObjects(void);
 void rdbLoadProgressCallback(rio *r, const void *buf, size_t len);
 void computeDatasetProfile(int dbid, robj *keyobj, robj *o, long long expiretime);
+void rdbCheckSetError(const char *fmt, ...);
 
 int rdbCheckMode = 0;
 int rdbCheckStats = 0;
@@ -361,8 +362,9 @@ void computeDatasetProfile(int dbid, robj *keyobj, robj *o, long long expiretime
         streamIteratorStart(&si, objectGetVal(o), NULL, NULL, 0);
         streamID id;
         int64_t numfields;
+        streamIteratorResult result;
 
-        while (streamIteratorGetID(&si, &id, &numfields)) {
+        while ((result = streamIteratorGetID(&si, &id, &numfields)) == STREAM_ITERATOR_FOUND) {
             while (numfields--) {
                 unsigned char *field, *value;
                 int64_t field_len, value_len;
@@ -371,6 +373,10 @@ void computeDatasetProfile(int dbid, robj *keyobj, robj *o, long long expiretime
             }
         }
         streamIteratorStop(&si);
+        if (result == STREAM_ITERATOR_CORRUPT) {
+            rdbCheckSetError("Stream listpack corruption detected");
+            return;
+        }
         statsRecordCount(streamLength(o), stats);
     } else if (o->type == OBJ_MODULE) {
         statsRecordCount(1, stats);
@@ -803,6 +809,12 @@ int redis_check_rdb(char *rdbfilename, FILE *fp) {
             }
 
             computeDatasetProfile(selected_dbid, key, val, expiretime);
+            if (rdbstate.error_set) {
+                rdbstate.key = NULL;
+                decrRefCount(key);
+                decrRefCount(val);
+                goto eoferr;
+            }
         }
         /* Check if the key already expired. */
         if (expiretime != -1 && expiretime < now) rdbstate.already_expired++;

--- a/tests/integration/corrupt-dump.tcl
+++ b/tests/integration/corrupt-dump.tcl
@@ -264,12 +264,96 @@ test {corrupt payload: hash listpack with duplicate records - convert} {
     }
 }
 
+proc assert_restore_rejects_corrupt_payload {key payload} {
+    assert_equal 1 [catch {r restore $key 0 $payload} err]
+    assert_match "*Bad data format*" $err
+    assert_equal 0 [r exists $key]
+}
+
+test {corrupt payload: F1 inflated listpack cached counts are safe} {
+    start_server [list overrides [list loglevel verbose use-exit-on-panic yes crash-memcheck-enabled no] ] {
+        # Each malformed payload was created from the valid control below by
+        # changing only the listpack num-elements header from its actual value
+        # to 4 and recomputing the DUMP CRC64.
+        set hash_valid "\x10\x0D\x0D\x00\x00\x00\x02\x00\x81\x66\x02\x81\x76\x02\xFF\x50\x00\xEF\xDB\xF4\xD5\xBD\x06\x6F\x69"
+        set hash_bad "\x10\x0D\x0D\x00\x00\x00\x04\x00\x81\x66\x02\x81\x76\x02\xFF\x50\x00\xBB\x34\xAE\x20\x7B\xD9\x1B\xAE"
+        set zset_valid "\x11\x0C\x0C\x00\x00\x00\x02\x00\x81\x6D\x02\x01\x01\xFF\x50\x00\xE9\xC9\x34\x0C\x43\x2F\x09\x3F"
+        set zset_bad "\x11\x0C\x0C\x00\x00\x00\x04\x00\x81\x6D\x02\x01\x01\xFF\x50\x00\xFC\xEA\x8B\x9C\x96\x69\xBC\xA3"
+        set set_valid "\x14\x0D\x0D\x00\x00\x00\x02\x00\x81\x61\x02\x81\x62\x02\xFF\x50\x00\xAC\x19\x7E\x56\x2A\x6E\x58\x29"
+        set set_bad "\x14\x0D\x0D\x00\x00\x00\x04\x00\x81\x61\x02\x81\x62\x02\xFF\x50\x00\xF8\xF6\x24\xA3\xEC\xB1\x2C\xEE"
+
+        assert_restore_rejects_corrupt_payload badhash $hash_bad
+        assert_restore_rejects_corrupt_payload badzset $zset_bad
+        assert_restore_rejects_corrupt_payload badset $set_bad
+
+        verify_log_message 0 "*Hash listpack integrity check failed*" 0
+        verify_log_message 0 "*Zset listpack integrity check failed*" 0
+        verify_log_message 0 "*Set listpack integrity check failed*" 0
+
+        assert_equal OK [r restore validhash 0 $hash_valid]
+        assert_encoding listpack validhash
+        assert_equal 1 [r hlen validhash]
+        assert_equal 3 [llength [r hrandfield validhash -3]]
+        assert_equal 6 [llength [r hrandfield validhash -3 withvalues]]
+
+        assert_equal OK [r restore validzset 0 $zset_valid]
+        assert_encoding listpack validzset
+        assert_equal 1 [r zcard validzset]
+        assert_equal 3 [llength [r zrandmember validzset -3]]
+        assert_equal {m 1} [r zpopmin validzset 2]
+
+        assert_equal OK [r restore validset 0 $set_valid]
+        assert_encoding listpack validset
+        assert_equal 2 [r scard validset]
+        assert_equal 3 [llength [r srandmember validset -3]]
+        assert_equal {a b} [lsort [r spop validset 2]]
+        assert_equal PONG [r ping]
+    }
+}
+
+test {corrupt payload: F3 inflated stream field counts are safe} {
+    start_server [list overrides [list loglevel verbose use-exit-on-panic yes crash-memcheck-enabled no] ] {
+        # The control has two entries: the first uses the master field "f",
+        # and the second stores its own field "g". Each malformed payload
+        # changes only one field count from 1 to 2 and has a recomputed CRC64.
+        set stream_valid "\x15\x01\x10\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x2D\x2D\x00\x00\x00\x11\x00\x02\x01\x00\x01\x01\x01\x81\x66\x02\x00\x01\x02\x01\x00\x01\x00\x01\x81\x76\x02\x04\x01\x00\x01\x01\x01\x00\x01\x01\x01\x81\x67\x02\x81\x77\x02\x06\x01\xFF\x02\x02\x00\x01\x00\x00\x00\x02\x00\x50\x00\xA1\xDF\xE0\xE1\x48\xC5\xF8\x85"
+        set stream_bad_master "\x15\x01\x10\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x2D\x2D\x00\x00\x00\x11\x00\x02\x01\x00\x01\x02\x01\x81\x66\x02\x00\x01\x02\x01\x00\x01\x00\x01\x81\x76\x02\x04\x01\x00\x01\x01\x01\x00\x01\x01\x01\x81\x67\x02\x81\x77\x02\x06\x01\xFF\x02\x02\x00\x01\x00\x00\x00\x02\x00\x50\x00\x40\xF4\x7A\x80\xB6\xB5\x33\xF4"
+        set stream_bad_entry "\x15\x01\x10\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x2D\x2D\x00\x00\x00\x11\x00\x02\x01\x00\x01\x01\x01\x81\x66\x02\x00\x01\x02\x01\x00\x01\x00\x01\x81\x76\x02\x04\x01\x00\x01\x01\x01\x00\x01\x02\x01\x81\x67\x02\x81\x77\x02\x06\x01\xFF\x02\x02\x00\x01\x00\x00\x00\x02\x00\x50\x00\x26\xED\x27\xD7\x37\x55\x14\x7A"
+
+        assert_restore_rejects_corrupt_payload badstream-master $stream_bad_master
+        assert_restore_rejects_corrupt_payload badstream-entry $stream_bad_entry
+        verify_log_message 0 "*Stream listpack integrity check failed*" 0
+
+        assert_equal OK [r restore validstream 0 $stream_valid]
+        assert_equal 2 [r xlen validstream]
+        assert_equal {{1-0 {f v}} {2-0 {g w}}} [r xrange validstream - +]
+        assert_equal {{2-0 {g w}} {1-0 {f v}}} [r xrevrange validstream + -]
+        assert_equal {{validstream {{1-0 {f v}} {2-0 {g w}}}}} [r xread count 2 streams validstream 0-0]
+        assert_equal 2 [dict get [r xinfo stream validstream] length]
+        assert_equal PONG [r ping]
+    }
+}
+
 test {corrupt payload: hash ziplist uneven record count} {
     # when we do NOT perform full sanitization, but shallow sanitization can detect uneven count
     start_server [list overrides [list loglevel verbose use-exit-on-panic yes crash-memcheck-enabled no] ] {
         r debug set-skip-checksum-validation 1
         catch { r RESTORE _hash 0 "\r\x1b\x1b\x00\x00\x00\x16\x00\x00\x00\x04\x00\x00\x02a\x00\x04\x02b\x00\x04\x02a\x00\x04\x02d\x00\xff\t\x00\xa1\x98\x36x\xcc\x8e\x93\x2e" } err
         assert_match "*Bad data format*" $err
+    }
+}
+
+test {corrupt payload: stream live and deleted count split mismatch} {
+    start_server [list overrides [list loglevel verbose use-exit-on-panic yes crash-memcheck-enabled no] ] {
+        # Both records are live, but the listpack header declares one live and
+        # one deleted record. The total remains two. This payload keeps the
+        # valid control checksum, so skip checksum validation for this case.
+        set stream_bad_split "\x15\x01\x10\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x2D\x2D\x00\x00\x00\x11\x00\x01\x01\x01\x01\x01\x81\x66\x02\x00\x01\x02\x01\x00\x01\x00\x01\x81\x76\x02\x04\x01\x00\x01\x01\x01\x00\x01\x01\x01\x81\x67\x02\x81\x77\x02\x06\x01\xFF\x02\x02\x00\x01\x00\x00\x00\x02\x00\x50\x00\xA1\xDF\xE0\xE1\x48\xC5\xF8\x85"
+
+        r debug set-skip-checksum-validation 1
+        assert_restore_rejects_corrupt_payload badstream-split $stream_bad_split
+        verify_log_message 0 "*Stream listpack integrity check failed*" 0
+        assert_equal PONG [r ping]
     }
 }
 


### PR DESCRIPTION
## Summary
Hardens RESTORE and RDB loading against inconsistent count metadata in listpack-backed objects and streams.

## Findings
- A listpack could claim more cached elements than its bytes can contain. Random hash, set, and sorted-set readers could then seek past the real entries and consume uninitialized outputs.
- A stream listpack could claim more master or entry fields than are present, allowing readers to walk beyond the record boundary.

## Fix
- Reject structurally impossible cached listpack counts during shallow validation.
- Make listpack random selection fallible, initialize outputs, and require callers to consume only complete results.
- Validate stream master/entry field spans and trailing counts.
- Make forward and reverse stream iteration stop safely on incomplete records without introducing repeated full-listpack scans.

## Validation
- Full build passed.
- `integration/corrupt-dump`: 80 passed.
- `unit/type/hash`: 85 passed.
- `unit/type/set`: 118 passed.
- `unit/type/zset`: 333 passed.
- `unit/type/stream`: 83 passed.
- `git diff --check` and clang-format 18 source checks passed.

Draft in the fork for manual security review and backport assessment.