### PR TITLE
Validate replication RDB bulk lengths

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -2327,9 +2327,10 @@ void replicationAttachToNewPrimary(void) {
 
 /* During replication, the primary sends sync metadata as the first line
  * which can be either a standard bulk format ($<count>) or an EOF-delimited
- * format ($EOF:<delimiter>) for diskless transfers. We need this data in order
- * to detect transfer completion. This function reads and parses that
- * metadata line.
+ * format ($EOF:<delimiter>) for diskless transfers. The standard count must
+ * be a complete, non-negative decimal integer. We need this data in order to
+ * detect transfer completion. This function reads and parses that metadata
+ * line.
  * The primary may also send an error message starting with '-' or a ping
  * (newline) to keep the connection alive, in which case this function
  * should be called again later.
@@ -2341,18 +2342,27 @@ int tryReadBulkPayloadMetadata(connection *conn, char *buf, char *eofmark, char 
         return C_ERR;
     } else {
         /* nread here is returned by connSyncReadLine(), which calls syncReadLine() and
-         * convert "\r\n" to '\0' so 1 byte is lost. */
+         * converts "\r\n" to '\0' so 1 byte is lost. */
         if (inBioThread())
             server.bio_stat_net_repl_input_bytes += nread + 1;
         else
             server.stat_net_repl_input_bytes += nread + 1;
     }
 
-    /* Check the bulk payload header for errors */
-    if (buf[0] == '-') {
-        serverLog(LL_WARNING, "PRIMARY aborted replication with an error: %s", buf + 1);
+    size_t metadata_len = nread;
+    /* connSyncReadLine() counts the CR, but replaces it with NUL. */
+    if (metadata_len > 0 && buf[metadata_len - 1] == '\0') metadata_len--;
+
+    if (memchr(buf, '\0', metadata_len) != NULL) {
+        serverLog(LL_WARNING, "Invalid bulk metadata from PRIMARY: %.*s", (int)metadata_len, buf);
         return C_ERR;
-    } else if (buf[0] == '\0') {
+    }
+
+    /* Check the bulk payload header for errors */
+    if (metadata_len > 0 && buf[0] == '-') {
+        serverLog(LL_WARNING, "PRIMARY aborted replication with an error: %.*s", (int)metadata_len - 1, buf + 1);
+        return C_ERR;
+    } else if (metadata_len == 0) {
         /* At this stage just a newline works as a PING in order to take
          * the connection live. So we refresh our last interaction
          * timestamp. */
@@ -2360,14 +2370,14 @@ int tryReadBulkPayloadMetadata(connection *conn, char *buf, char *eofmark, char 
         return C_RETRY;
     } else if (buf[0] != '$') {
         serverLog(LL_WARNING,
-                  "Bad protocol from PRIMARY, the first byte is not '$' (we received '%s'), are you sure the host "
+                  "Bad protocol from PRIMARY, the first byte is not '$' (we received '%.*s'), are you sure the host "
                   "and port are right?",
-                  buf);
+                  (int)metadata_len, buf);
         return C_ERR;
     }
 
     /* Check if this is an EOF-based transfer ($EOF:<delimiter>) or size-based ($<size>) */
-    if (strncmp(buf + 1, "EOF:", 4) == 0 && strlen(buf + 5) >= RDB_EOF_MARK_SIZE) {
+    if (metadata_len >= 5 + RDB_EOF_MARK_SIZE && memcmp(buf + 1, "EOF:", 4) == 0) {
         /* EOF-based transfer: extract the delimiter */
         memcpy(eofmark, buf + 5, RDB_EOF_MARK_SIZE);
         memset(lastbytes, 0, RDB_EOF_MARK_SIZE);
@@ -2375,8 +2385,13 @@ int tryReadBulkPayloadMetadata(connection *conn, char *buf, char *eofmark, char 
         *repl_transfer_size = 0;
     } else {
         /* Size-based transfer: parse the size */
+        long long transfer_size;
+        if (!string2ll(buf + 1, metadata_len - 1, &transfer_size) || transfer_size < 0) {
+            serverLog(LL_WARNING, "Invalid bulk metadata from PRIMARY: %.*s", (int)metadata_len, buf);
+            return C_ERR;
+        }
         *usemark = false;
-        *repl_transfer_size = strtol(buf + 1, NULL, 10);
+        *repl_transfer_size = transfer_size;
     }
 
     return C_OK;
@@ -2500,7 +2515,7 @@ int replicaLoadPrimaryRDBFromSocket(connection *conn, char *buf, char *eofmark, 
         functions_lib_ctx = functionsLibCtxGetCurrent();
     }
 
-    rioInitWithConn(&rdb, conn, server.repl_transfer_size);
+    rioInitWithConn(&rdb, conn, (uint64_t)server.repl_transfer_size);
 
     /* Put the socket in blocking mode to simplify RDB transfer.
      * We'll restore it when the RDB is received. */

--- a/src/rio.c
+++ b/src/rio.c
@@ -233,7 +233,9 @@ static size_t rioConnRead(rio *r, void *buf, size_t len) {
     /* Make sure the caller didn't request to read past the limit.
      * If they didn't we'll buffer till the limit, if they did, we'll
      * return an error. */
-    if (r->io.conn.read_limit != 0 && r->io.conn.read_limit < r->io.conn.read_so_far + len) {
+    if (len > UINT64_MAX - r->io.conn.read_so_far ||
+        (r->io.conn.read_limit != 0 &&
+         (r->io.conn.read_so_far > r->io.conn.read_limit || len > r->io.conn.read_limit - r->io.conn.read_so_far))) {
         errno = EOVERFLOW;
         return 0;
     }
@@ -246,8 +248,13 @@ static size_t rioConnRead(rio *r, void *buf, size_t len) {
          * the two. */
         size_t toread = needs < PROTO_IOBUF_LEN ? PROTO_IOBUF_LEN : needs;
         if (toread > sdsavail(r->io.conn.buf)) toread = sdsavail(r->io.conn.buf);
-        if (r->io.conn.read_limit != 0 && r->io.conn.read_so_far + buffered + toread > r->io.conn.read_limit) {
-            toread = r->io.conn.read_limit - r->io.conn.read_so_far - buffered;
+        if (r->io.conn.read_limit != 0) {
+            uint64_t remaining = r->io.conn.read_limit - r->io.conn.read_so_far;
+            if (buffered > remaining || (remaining -= buffered) == 0) {
+                errno = EOVERFLOW;
+                return 0;
+            }
+            if (toread > remaining) toread = (size_t)remaining;
         }
         int retval = connRead(r->io.conn.conn, (char *)r->io.conn.buf + sdslen(r->io.conn.buf), toread);
         if (retval == 0) {
@@ -294,7 +301,7 @@ static const rio rioConnIO = {
 
 /* Create an RIO that implements a buffered read from an fd
  * read_limit argument stops buffering when the reaching the limit. */
-void rioInitWithConn(rio *r, connection *conn, size_t read_limit) {
+void rioInitWithConn(rio *r, connection *conn, uint64_t read_limit) {
     *r = rioConnIO;
     r->io.conn.conn = conn;
     r->io.conn.pos = 0;

--- a/src/rio.h
+++ b/src/rio.h
@@ -87,11 +87,11 @@ struct _rio {
         } file;
         /* Connection object (used to read from socket) */
         struct {
-            connection *conn;   /* Connection */
-            off_t pos;          /* pos in buf that was returned */
-            sds buf;            /* buffered data */
-            size_t read_limit;  /* don't allow to buffer/read more than that */
-            size_t read_so_far; /* amount of data read from the rio (not buffered) */
+            connection *conn;     /* Connection */
+            off_t pos;            /* pos in buf that was returned */
+            sds buf;              /* buffered data */
+            uint64_t read_limit;  /* don't allow to buffer/read more than that */
+            uint64_t read_so_far; /* amount of data read from the rio (not buffered) */
         } conn;
         /* FD target (used to write to pipe). */
         struct {
@@ -185,7 +185,7 @@ static inline void rioClearErrors(rio *r) {
 
 void rioInitWithFile(rio *r, FILE *fp);
 void rioInitWithBuffer(rio *r, sds s);
-void rioInitWithConn(rio *r, connection *conn, size_t read_limit);
+void rioInitWithConn(rio *r, connection *conn, uint64_t read_limit);
 void rioInitWithFd(rio *r, int fd);
 
 void rioFreeFd(rio *r);

--- a/tests/helpers/fake_redis_node.tcl
+++ b/tests/helpers/fake_redis_node.tcl
@@ -3,7 +3,9 @@
 # Usage: tclsh fake_redis_node.tcl PORT COMMAND REPLY [ COMMAND REPLY [ ... ] ]
 #
 # Commands are given as space-separated strings, e.g. "GET foo", and replies as
-# RESP-encoded replies minus the trailing \r\n, e.g. "+OK".
+# RESP-encoded replies minus the trailing \r\n, e.g. "+OK". Prefix a reply
+# with "hex:" to send decoded binary content. Dynamic PSYNC expectations may
+# opt into glob matching with an explicit "glob:" prefix.
 
 set port [lindex $argv 0];
 set expected_traffic [lrange $argv 1 end];
@@ -42,7 +44,16 @@ proc accept {sock host port} {
     foreach {expect_cmd reply} $expected_traffic {
         if {[eof $sock]} {break}
         set cmd [read_command $sock]
-        if {[string equal -nocase $cmd $expect_cmd]} {
+        set command_matches [string equal -nocase $cmd $expect_cmd]
+        if {!$command_matches &&
+            [string equal -nocase [string range $expect_cmd 0 10] "glob:PSYNC "] &&
+            [string equal -nocase [lindex $cmd 0] "PSYNC"]} {
+            set command_matches [string match -nocase [string range $expect_cmd 5 end] $cmd]
+        }
+        if {$command_matches} {
+            if {[string equal [string range $reply 0 3] "hex:"]} {
+                set reply [binary format H* [string range $reply 4 end]]
+            }
             puts $sock $reply
             flush $sock
         } else {

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -751,6 +751,89 @@ foreach testType {Successful Aborted} {
     }
 }
 
+proc stop_fake_primary {pid} {
+    catch {exec kill $pid}
+    wait_for_condition 100 10 {
+        ![is_alive $pid]
+    } else {
+        catch {exec kill -KILL $pid}
+        wait_for_condition 100 10 {
+            ![is_alive $pid]
+        } else {
+            fail "Fake primary process $pid did not exit"
+        }
+    }
+}
+
+proc test_fake_primary_bulk_length {bulk_payload expect_rejection} {
+    start_server {tags {repl external:skip tls:skip} overrides {save "" repl-diskless-load swapdb}} {
+        set replica [srv 0 client]
+        set fake_port [find_available_port $::baseport $::portcount]
+        set tclsh [info nameofexecutable]
+        set script "tests/helpers/fake_redis_node.tcl"
+        # Encode the reply so binary metadata, including NUL, survives exec argv.
+        set fullresync_reply "+FULLRESYNC [string repeat a 40] 0\n$bulk_payload"
+        binary scan $fullresync_reply H* encoded_reply
+        set encoded_reply "hex:$encoded_reply"
+        # Socket output translation converts each newline to exactly CRLF.
+        set fake_pid [exec $tclsh $script $fake_port \
+            "PING" "+PONG" \
+            "REPLCONF listening-port [srv 0 port]" "+OK" \
+            "REPLCONF capa eof capa psync2" "+OK" \
+            "REPLCONF version [s 0 valkey_version]" "+OK" \
+            "glob:PSYNC *" $encoded_reply &]
+
+        set errcode [catch {
+            wait_for_condition 50 10 {
+                [catch {close [socket 127.0.0.1 $fake_port]}] == 0
+            } else {
+                fail "Fake primary did not start listening"
+            }
+
+            set loglines [count_log_lines 0]
+            $replica replicaof 127.0.0.1 $fake_port
+            if {$expect_rejection} {
+                wait_for_log_messages 0 {"*Invalid bulk metadata from PRIMARY*"} $loglines 100 10
+                verify_no_log_message 0 "*Loading DB in memory*" $loglines
+                assert_equal down [s 0 master_link_status]
+            } else {
+                wait_for_log_messages 0 {"*Loading DB in memory*"} $loglines 100 10
+                verify_no_log_message 0 "*Failed to read sync metadata*" $loglines
+            }
+            assert_equal PONG [$replica ping]
+        } result options]
+        catch {$replica replicaof no one}
+        set cleanup_errcode [catch {
+            stop_fake_primary $fake_pid
+        } cleanup_result cleanup_options]
+        if {$errcode} {
+            return -options $options $result
+        }
+        if {$cleanup_errcode} {
+            return -options $cleanup_options $cleanup_result
+        }
+    }
+}
+
+foreach {description bulk_payload} [list \
+    {null bulk length} {$-1} \
+    {signed-overflow bulk length} {$9223372036854775808} \
+    {bulk length with trailing garbage} {$1x} \
+    {bulk length with embedded NUL} "\$1\x00garbage"] {
+    test "Diskless replica rejects fake primary $description" {
+        test_fake_primary_bulk_length $bulk_payload 1
+    }
+}
+
+test {Diskless replica accepts valid fake primary bulk length} {
+    # Socket output translates each newline to CRLF.
+    test_fake_primary_bulk_length "\$1\nx" 0
+}
+
+test {Diskless replica accepts fake primary bulk length at 2^32 boundary} {
+    test_fake_primary_bulk_length {$4294967296} 0
+}
+
 test {diskless loading short read} {
     start_server {tags {"repl"} overrides {save ""}} {
         set replica [srv 0 client]


### PR DESCRIPTION
## Summary
Validates the RDB bulk-length metadata received from a primary before starting a full synchronization transfer.

## Finding
The size-based synchronization header was parsed with unchecked `strtol`. A negative value such as `$-1`, signed overflow, or trailing garbage could reach later replication paths with an invalid transfer size. In diskless loading this could trigger a server assertion and terminate the replica.

## Fix
- Parse the complete decimal field with `string2ll`.
- Reject negative, overflowed, noncanonical, and trailing-garbage values before assigning the transfer size.
- Fail the replication handshake cleanly on invalid metadata.
- Preserve EOF-delimited synchronization and valid large RDB transfers without applying the client request bulk limit.

## Validation
- Full build passed.
- Full `integration/replication` suite: 73 passed.
- Added fake-primary coverage for negative length, signed overflow, trailing garbage, and a valid size-based control.
- `git diff --check` and clang-format 18 source checks passed.

Draft in the fork for manual security review and backport assessment.