### PR TITLE
Validate replication RDB bulk lengths

### DIFF
--- a/src/replication.c
+++ b/src/replication.c
@@ -2327,9 +2327,9 @@ void replicationAttachToNewPrimary(void) {
 
 /* During replication, the primary sends sync metadata as the first line
  * which can be either a standard bulk format ($<count>) or an EOF-delimited
- * format ($EOF:<delimiter>) for diskless transfers. We need this data in order
- * to detect transfer completion. This function reads and parses that
- * metadata line.
+ * format ($EOF:<delimiter>) for diskless transfers. A size-based count must be
+ * a complete, positive decimal integer. We need this data in order to detect
+ * transfer completion. This function reads and parses that metadata line.
  * The primary may also send an error message starting with '-' or a ping
  * (newline) to keep the connection alive, in which case this function
  * should be called again later.
@@ -2341,18 +2341,28 @@ int tryReadBulkPayloadMetadata(connection *conn, char *buf, char *eofmark, char 
         return C_ERR;
     } else {
         /* nread here is returned by connSyncReadLine(), which calls syncReadLine() and
-         * convert "\r\n" to '\0' so 1 byte is lost. */
+         * converts "\r\n" to '\0' so 1 byte is lost. */
         if (inBioThread())
             server.bio_stat_net_repl_input_bytes += nread + 1;
         else
             server.stat_net_repl_input_bytes += nread + 1;
     }
 
-    /* Check the bulk payload header for errors */
-    if (buf[0] == '-') {
-        serverLog(LL_WARNING, "PRIMARY aborted replication with an error: %s", buf + 1);
+    size_t metadata_len = nread;
+    /* connSyncReadLine() turns a stripped CR into NUL but still counts it, so
+     * drop a trailing NUL before checking for one inside the line. */
+    if (metadata_len > 0 && buf[metadata_len - 1] == '\0') metadata_len--;
+
+    if (memchr(buf, '\0', metadata_len) != NULL) {
+        serverLog(LL_WARNING, "Invalid bulk metadata from PRIMARY: %.*s", (int)metadata_len, buf);
         return C_ERR;
-    } else if (buf[0] == '\0') {
+    }
+
+    /* Check the bulk payload header for errors */
+    if (metadata_len > 0 && buf[0] == '-') {
+        serverLog(LL_WARNING, "PRIMARY aborted replication with an error: %.*s", (int)metadata_len - 1, buf + 1);
+        return C_ERR;
+    } else if (metadata_len == 0) {
         /* At this stage just a newline works as a PING in order to take
          * the connection live. So we refresh our last interaction
          * timestamp. */
@@ -2360,23 +2370,29 @@ int tryReadBulkPayloadMetadata(connection *conn, char *buf, char *eofmark, char 
         return C_RETRY;
     } else if (buf[0] != '$') {
         serverLog(LL_WARNING,
-                  "Bad protocol from PRIMARY, the first byte is not '$' (we received '%s'), are you sure the host "
+                  "Bad protocol from PRIMARY, the first byte is not '$' (we received '%.*s'), are you sure the host "
                   "and port are right?",
-                  buf);
+                  (int)metadata_len, buf);
         return C_ERR;
     }
 
     /* Check if this is an EOF-based transfer ($EOF:<delimiter>) or size-based ($<size>) */
-    if (strncmp(buf + 1, "EOF:", 4) == 0 && strlen(buf + 5) >= RDB_EOF_MARK_SIZE) {
+    if (metadata_len >= 5 + RDB_EOF_MARK_SIZE && memcmp(buf + 1, "EOF:", 4) == 0) {
         /* EOF-based transfer: extract the delimiter */
         memcpy(eofmark, buf + 5, RDB_EOF_MARK_SIZE);
         memset(lastbytes, 0, RDB_EOF_MARK_SIZE);
         *usemark = true;
         *repl_transfer_size = 0;
     } else {
-        /* Size-based transfer: parse the size */
+        /* Size-based transfer: parse the size. 0 is reserved for the EOF form
+         * above, and a real RDB is never empty, so require a positive count. */
+        long long transfer_size;
+        if (!string2ll(buf + 1, metadata_len - 1, &transfer_size) || transfer_size <= 0) {
+            serverLog(LL_WARNING, "Invalid bulk metadata from PRIMARY: %.*s", (int)metadata_len, buf);
+            return C_ERR;
+        }
         *usemark = false;
-        *repl_transfer_size = strtol(buf + 1, NULL, 10);
+        *repl_transfer_size = transfer_size;
     }
 
     return C_OK;
@@ -2500,7 +2516,7 @@ int replicaLoadPrimaryRDBFromSocket(connection *conn, char *buf, char *eofmark, 
         functions_lib_ctx = functionsLibCtxGetCurrent();
     }
 
-    rioInitWithConn(&rdb, conn, server.repl_transfer_size);
+    rioInitWithConn(&rdb, conn, (uint64_t)server.repl_transfer_size);
 
     /* Put the socket in blocking mode to simplify RDB transfer.
      * We'll restore it when the RDB is received. */

--- a/src/rio.c
+++ b/src/rio.c
@@ -233,7 +233,9 @@ static size_t rioConnRead(rio *r, void *buf, size_t len) {
     /* Make sure the caller didn't request to read past the limit.
      * If they didn't we'll buffer till the limit, if they did, we'll
      * return an error. */
-    if (r->io.conn.read_limit != 0 && r->io.conn.read_limit < r->io.conn.read_so_far + len) {
+    if (len > UINT64_MAX - r->io.conn.read_so_far ||
+        (r->io.conn.read_limit != 0 &&
+         (r->io.conn.read_so_far > r->io.conn.read_limit || len > r->io.conn.read_limit - r->io.conn.read_so_far))) {
         errno = EOVERFLOW;
         return 0;
     }
@@ -246,8 +248,13 @@ static size_t rioConnRead(rio *r, void *buf, size_t len) {
          * the two. */
         size_t toread = needs < PROTO_IOBUF_LEN ? PROTO_IOBUF_LEN : needs;
         if (toread > sdsavail(r->io.conn.buf)) toread = sdsavail(r->io.conn.buf);
-        if (r->io.conn.read_limit != 0 && r->io.conn.read_so_far + buffered + toread > r->io.conn.read_limit) {
-            toread = r->io.conn.read_limit - r->io.conn.read_so_far - buffered;
+        if (r->io.conn.read_limit != 0) {
+            uint64_t remaining = r->io.conn.read_limit - r->io.conn.read_so_far;
+            if (buffered > remaining || (remaining -= buffered) == 0) {
+                errno = EOVERFLOW;
+                return 0;
+            }
+            if (toread > remaining) toread = (size_t)remaining;
         }
         int retval = connRead(r->io.conn.conn, (char *)r->io.conn.buf + sdslen(r->io.conn.buf), toread);
         if (retval == 0) {
@@ -294,7 +301,7 @@ static const rio rioConnIO = {
 
 /* Create an RIO that implements a buffered read from an fd
  * read_limit argument stops buffering when the reaching the limit. */
-void rioInitWithConn(rio *r, connection *conn, size_t read_limit) {
+void rioInitWithConn(rio *r, connection *conn, uint64_t read_limit) {
     *r = rioConnIO;
     r->io.conn.conn = conn;
     r->io.conn.pos = 0;

--- a/src/rio.h
+++ b/src/rio.h
@@ -87,11 +87,11 @@ struct _rio {
         } file;
         /* Connection object (used to read from socket) */
         struct {
-            connection *conn;   /* Connection */
-            off_t pos;          /* pos in buf that was returned */
-            sds buf;            /* buffered data */
-            size_t read_limit;  /* don't allow to buffer/read more than that */
-            size_t read_so_far; /* amount of data read from the rio (not buffered) */
+            connection *conn;     /* Connection */
+            off_t pos;            /* pos in buf that was returned */
+            sds buf;              /* buffered data */
+            uint64_t read_limit;  /* don't allow to buffer/read more than that */
+            uint64_t read_so_far; /* amount of data read from the rio (not buffered) */
         } conn;
         /* FD target (used to write to pipe). */
         struct {
@@ -185,7 +185,7 @@ static inline void rioClearErrors(rio *r) {
 
 void rioInitWithFile(rio *r, FILE *fp);
 void rioInitWithBuffer(rio *r, sds s);
-void rioInitWithConn(rio *r, connection *conn, size_t read_limit);
+void rioInitWithConn(rio *r, connection *conn, uint64_t read_limit);
 void rioInitWithFd(rio *r, int fd);
 
 void rioFreeFd(rio *r);

--- a/src/unit/test_rio.cpp
+++ b/src/unit/test_rio.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Valkey Contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "generated_wrappers.hpp"
+
+#include <cerrno>
+#include <cstring>
+
+extern "C" {
+#include "rio.h"
+#include "server.h"
+}
+
+/* Tests for the overflow-safe read accounting in rioConnRead().
+ *
+ * These tests cover the 64-bit arithmetic only. They cannot reproduce the
+ * 32-bit size_t narrowing of a replication bulk length (where 4294967296
+ * truncates to 0 and RIO then treats the limit as unlimited), because size_t
+ * is 64 bits wide on the hosts these tests run on. What they do verify is that
+ * rioInitWithConn() keeps the limit at full 64-bit width and that the guards
+ * in rioConnRead() reject requests that would wrap around.
+ *
+ * All three checks are evaluated before rioConnRead() ever calls connRead(),
+ * so a zeroed stub connection is enough and no socket is needed. The
+ * requested lengths are kept small so that the buffer preallocated by
+ * rioInitWithConn() is never grown. */
+
+static ConnectionType CT_Stub;
+
+class RioConnOverflowTest : public ::testing::Test {
+  protected:
+    static void SetUpTestSuite() {
+        /* A zeroed connection type is sufficient: none of its callbacks are
+         * reached by the tests below. */
+        memset(&CT_Stub, 0, sizeof(CT_Stub));
+    }
+
+    void SetUp() override {
+        memset(&conn, 0, sizeof(conn));
+        conn.type = &CT_Stub;
+        conn.fd = -1;
+    }
+
+    connection conn;
+};
+
+/* The read limit is stored at full 64-bit width, not narrowed to size_t of a
+ * smaller build or truncated to 0. */
+TEST_F(RioConnOverflowTest, InitKeepsFullWidthReadLimit) {
+    rio r;
+    rioInitWithConn(&r, &conn, UINT64_C(4294967296));
+    EXPECT_EQ(r.io.conn.read_limit, UINT64_C(4294967296));
+    EXPECT_EQ(r.io.conn.read_so_far, UINT64_C(0));
+    rioFreeConn(&r, NULL);
+}
+
+/* A request that would push the running total past UINT64_MAX is rejected
+ * with EOVERFLOW, even when no read limit is set. */
+TEST_F(RioConnOverflowTest, ReadRejectsWrapAroundOfReadSoFar) {
+    rio r;
+    char buf[64];
+
+    rioInitWithConn(&r, &conn, 0);
+    r.io.conn.read_so_far = UINT64_MAX - 10;
+    errno = 0;
+    EXPECT_EQ(rioRead(&r, buf, 64), 0);
+    EXPECT_EQ(errno, EOVERFLOW);
+    rioFreeConn(&r, NULL);
+}
+
+/* A running total that already exceeds the read limit is rejected with
+ * EOVERFLOW instead of computing a negative remainder. */
+TEST_F(RioConnOverflowTest, ReadRejectsReadSoFarBeyondReadLimit) {
+    rio r;
+    char buf[8];
+
+    rioInitWithConn(&r, &conn, 100);
+    r.io.conn.read_so_far = 200;
+    errno = 0;
+    EXPECT_EQ(rioRead(&r, buf, 8), 0);
+    EXPECT_EQ(errno, EOVERFLOW);
+    rioFreeConn(&r, NULL);
+}

--- a/tests/helpers/fake_redis_node.tcl
+++ b/tests/helpers/fake_redis_node.tcl
@@ -3,7 +3,9 @@
 # Usage: tclsh fake_redis_node.tcl PORT COMMAND REPLY [ COMMAND REPLY [ ... ] ]
 #
 # Commands are given as space-separated strings, e.g. "GET foo", and replies as
-# RESP-encoded replies minus the trailing \r\n, e.g. "+OK".
+# RESP-encoded replies minus the trailing \r\n, e.g. "+OK". Prefix a reply
+# with "hex:" to send decoded binary content. Dynamic PSYNC expectations may
+# opt into glob matching with an explicit "glob:" prefix.
 
 set port [lindex $argv 0];
 set expected_traffic [lrange $argv 1 end];
@@ -42,7 +44,16 @@ proc accept {sock host port} {
     foreach {expect_cmd reply} $expected_traffic {
         if {[eof $sock]} {break}
         set cmd [read_command $sock]
-        if {[string equal -nocase $cmd $expect_cmd]} {
+        set command_matches [string equal -nocase $cmd $expect_cmd]
+        if {!$command_matches &&
+            [string equal -nocase [string range $expect_cmd 0 10] "glob:PSYNC "] &&
+            [string equal -nocase [lindex $cmd 0] "PSYNC"]} {
+            set command_matches [string match -nocase [string range $expect_cmd 5 end] $cmd]
+        }
+        if {$command_matches} {
+            if {[string equal [string range $reply 0 3] "hex:"]} {
+                set reply [binary format H* [string range $reply 4 end]]
+            }
             puts $sock $reply
             flush $sock
         } else {

--- a/tests/helpers/fake_redis_node.tcl
+++ b/tests/helpers/fake_redis_node.tcl
@@ -41,6 +41,15 @@ proc read_command {sock} {
 
 proc accept {sock host port} {
     global expected_traffic
+    # Treat the socket as a byte stream so binary replies are written verbatim
+    # instead of being re-encoded by the system encoding. Under a UTF-8 locale
+    # any byte >= 0x80 would otherwise be written as a multi-byte sequence, and
+    # depending on the Tcl version U+0000 may be written as the modified UTF-8
+    # sequence 0xC0 0x80 rather than a real NUL. Do not use
+    # "-translation binary": these replies are written with puts and the
+    # existing users of this helper rely on the CRLF that the default output
+    # translation appends.
+    fconfigure $sock -encoding iso8859-1
     foreach {expect_cmd reply} $expected_traffic {
         if {[eof $sock]} {break}
         set cmd [read_command $sock]

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -765,8 +765,12 @@ proc stop_fake_primary {pid} {
     }
 }
 
-proc test_fake_primary_bulk_length {bulk_payload expect_rejection} {
-    start_server {tags {repl external:skip tls:skip} overrides {save "" repl-diskless-load swapdb}} {
+proc test_fake_primary_bulk_length {bulk_payload expect_rejection {diskless_load swapdb}} {
+    # The metadata is parsed before the load path is chosen, so run the cases
+    # with both repl-diskless-load swapdb (in-memory load) and the default
+    # disabled (the RDB is written to disk from the bio thread).
+    start_server [list tags {repl external:skip tls:skip} \
+                      overrides [list save {} repl-diskless-load $diskless_load]] {
         set replica [srv 0 client]
         set fake_port [find_available_port $::baseport $::portcount]
         set tclsh [info nameofexecutable]
@@ -793,11 +797,11 @@ proc test_fake_primary_bulk_length {bulk_payload expect_rejection} {
             set loglines [count_log_lines 0]
             $replica replicaof 127.0.0.1 $fake_port
             if {$expect_rejection} {
-                wait_for_log_messages 0 {"*Invalid bulk metadata from PRIMARY*"} $loglines 100 10
+                wait_for_log_messages 0 {"*Invalid bulk metadata from PRIMARY*"} $loglines 1500 10
                 verify_no_log_message 0 "*Loading DB in memory*" $loglines
                 assert_equal down [s 0 master_link_status]
             } else {
-                wait_for_log_messages 0 {"*Loading DB in memory*"} $loglines 100 10
+                wait_for_log_messages 0 {"*Loading DB in memory*"} $loglines 1500 10
                 verify_no_log_message 0 "*Failed to read sync metadata*" $loglines
             }
             assert_equal PONG [$replica ping]
@@ -819,10 +823,14 @@ foreach {description bulk_payload} [list \
     {null bulk length} {$-1} \
     {zero bulk length} {$0} \
     {signed-overflow bulk length} {$9223372036854775808} \
+    {bulk length with leading plus} {$+1} \
+    {bulk length with leading zero} {$01} \
     {bulk length with trailing garbage} {$1x} \
     {bulk length with embedded NUL} "\$1\x00garbage"] {
-    test "Diskless replica rejects fake primary $description" {
-        test_fake_primary_bulk_length $bulk_payload 1
+    foreach diskless_load {swapdb disabled} {
+        test "Replica with repl-diskless-load $diskless_load rejects fake primary $description" {
+            test_fake_primary_bulk_length $bulk_payload 1 $diskless_load
+        }
     }
 }
 
@@ -831,7 +839,13 @@ test {Diskless replica accepts valid fake primary bulk length} {
     test_fake_primary_bulk_length "\$1\nx" 0
 }
 
-test {Diskless replica accepts fake primary bulk length at 2^32 boundary} {
+# This only asserts that a bulk length above 2^32 is accepted and that loading
+# starts. It does NOT cover the 32-bit size_t narrowing bug: before the fix, a
+# 32-bit build narrowed 4294967296 to 0, and RIO treats a 0 read limit as
+# unlimited, so loading started there too and this test still passed. The
+# overflow-safe arithmetic itself is covered by RioConnOverflowTest in
+# src/unit/test_rio.cpp.
+test {Diskless replica accepts fake primary bulk length above 2^32} {
     test_fake_primary_bulk_length {$4294967296} 0
 }
 

--- a/tests/integration/replication.tcl
+++ b/tests/integration/replication.tcl
@@ -751,6 +751,90 @@ foreach testType {Successful Aborted} {
     }
 }
 
+proc stop_fake_primary {pid} {
+    catch {exec kill $pid}
+    wait_for_condition 100 10 {
+        ![is_alive $pid]
+    } else {
+        catch {exec kill -KILL $pid}
+        wait_for_condition 100 10 {
+            ![is_alive $pid]
+        } else {
+            fail "Fake primary process $pid did not exit"
+        }
+    }
+}
+
+proc test_fake_primary_bulk_length {bulk_payload expect_rejection} {
+    start_server {tags {repl external:skip tls:skip} overrides {save "" repl-diskless-load swapdb}} {
+        set replica [srv 0 client]
+        set fake_port [find_available_port $::baseport $::portcount]
+        set tclsh [info nameofexecutable]
+        set script "tests/helpers/fake_redis_node.tcl"
+        # Encode the reply so binary metadata, including NUL, survives exec argv.
+        set fullresync_reply "+FULLRESYNC [string repeat a 40] 0\n$bulk_payload"
+        binary scan $fullresync_reply H* encoded_reply
+        set encoded_reply "hex:$encoded_reply"
+        # Socket output translation converts each newline to exactly CRLF.
+        set fake_pid [exec $tclsh $script $fake_port \
+            "PING" "+PONG" \
+            "REPLCONF listening-port [srv 0 port]" "+OK" \
+            "REPLCONF capa eof capa psync2" "+OK" \
+            "REPLCONF version [s 0 valkey_version]" "+OK" \
+            "glob:PSYNC *" $encoded_reply &]
+
+        set errcode [catch {
+            wait_for_condition 50 10 {
+                [catch {close [socket 127.0.0.1 $fake_port]}] == 0
+            } else {
+                fail "Fake primary did not start listening"
+            }
+
+            set loglines [count_log_lines 0]
+            $replica replicaof 127.0.0.1 $fake_port
+            if {$expect_rejection} {
+                wait_for_log_messages 0 {"*Invalid bulk metadata from PRIMARY*"} $loglines 100 10
+                verify_no_log_message 0 "*Loading DB in memory*" $loglines
+                assert_equal down [s 0 master_link_status]
+            } else {
+                wait_for_log_messages 0 {"*Loading DB in memory*"} $loglines 100 10
+                verify_no_log_message 0 "*Failed to read sync metadata*" $loglines
+            }
+            assert_equal PONG [$replica ping]
+        } result options]
+        catch {$replica replicaof no one}
+        set cleanup_errcode [catch {
+            stop_fake_primary $fake_pid
+        } cleanup_result cleanup_options]
+        if {$errcode} {
+            return -options $options $result
+        }
+        if {$cleanup_errcode} {
+            return -options $cleanup_options $cleanup_result
+        }
+    }
+}
+
+foreach {description bulk_payload} [list \
+    {null bulk length} {$-1} \
+    {zero bulk length} {$0} \
+    {signed-overflow bulk length} {$9223372036854775808} \
+    {bulk length with trailing garbage} {$1x} \
+    {bulk length with embedded NUL} "\$1\x00garbage"] {
+    test "Diskless replica rejects fake primary $description" {
+        test_fake_primary_bulk_length $bulk_payload 1
+    }
+}
+
+test {Diskless replica accepts valid fake primary bulk length} {
+    # Socket output translates each newline to CRLF.
+    test_fake_primary_bulk_length "\$1\nx" 0
+}
+
+test {Diskless replica accepts fake primary bulk length at 2^32 boundary} {
+    test_fake_primary_bulk_length {$4294967296} 0
+}
+
 test {diskless loading short read} {
     start_server {tags {"repl"} overrides {save ""}} {
         set replica [srv 0 client]


### PR DESCRIPTION
## Summary
Validates the RDB bulk-length metadata a replica receives from a primary before starting a full synchronization transfer, and keeps the transfer boundary intact on 32-bit builds.

## Findings
- The size-based header was parsed with unchecked `strtol`. A negative value such as `$-1`, signed overflow, or trailing garbage could reach later replication paths as a transfer size. In diskless loading this could trigger a server assertion and terminate the replica.
- Parsing used `strlen` on a buffer whose real length was already known, so a NUL byte could hide the rest of the line. `$1\0garbage` was accepted as `$1` and the replica proceeded to load an RDB.
- `$0` was accepted as a size-based length, but 0 is how this code represents an EOF-delimited transfer. With `usemark` false, disk-based sync retries zero-byte reads and diskless sync passes a zero read limit to RIO, which RIO treats as unlimited.
- The size is stored in `off_t` (64-bit) but was passed to `rioInitWithConn()` as `size_t`. On 32-bit builds 2^32 narrows to 0, which again means unlimited, so the declared boundary disappeared. The RIO limit arithmetic could also overflow.

## Fix
- Parse the complete decimal field with `string2ll` using the known length, and reject negative, zero, overflowed, and trailing-garbage values.
- Reject an interior NUL and stop using C-string functions on the metadata line.
- Make the RIO connection read limit and counter `uint64_t`, and phrase the limit checks as subtraction so they cannot wrap.
- Preserve EOF-delimited synchronization and valid large RDB transfers, without applying the client request bulk limit.

## Compatibility
No DUMP or RDB format change and no wire protocol change. Real primaries send canonical decimal lengths, so ordinary replication including across versions is unaffected. A custom primary sending `$+1`, `$01`, or a length with stray whitespace will now fail the sync.

## Validation
- Full build passed.
- Full `integration/replication` suite: 77 passed.
- Fake-primary coverage for `$-1`, `$0`, signed overflow, trailing garbage, embedded NUL, a valid control, and the 2^32 boundary.
- Each rejection case was checked against the unpatched code. The embedded-NUL and `$0` cases fail there, the latter by hanging the replica rather than rejecting.
- `git diff --check` and clang-format 18 source checks passed.
- The 32-bit narrowing is verified by types and inspection only. Upstream CI has `build-32bit` but no 32-bit test run, and `-m32` was unavailable locally.

Draft in the fork for manual security review and backport assessment.
